### PR TITLE
Feat: Create skeleton page for trash stats

### DIFF
--- a/src/pages/DummyStatsPage.jsx
+++ b/src/pages/DummyStatsPage.jsx
@@ -1,30 +1,160 @@
-import { Card, CardBody, Text } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { Box, Button, Card, CardBody, HStack, Heading, Select, Text } from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+import { useEffect, useRef, useState } from 'react';
 import Backend from '../utils/utils';
 
 const DummyStatsPage = () => {
+  return (
+    <>
+      <AllStats />
+      <StatsByEvent />
+      <StatsByProfile />
+    </>
+  );
+};
+
+const AllStats = () => {
   const [stats, setStats] = useState(null);
   useEffect(() => {
-    getVolunteerData().then(data => setStats(data));
+    getStatsData().then(data => setStats(data));
   }, []);
   return (
-    <Card m="8">
+    <Box m="8">
+      <Heading>All trash</Heading>
+      <VolunteerTrashCollectedCard title="Total Trash Collected" amount={stats} />
+    </Box>
+  );
+};
+
+const StatsByEvent = () => {
+  const [stats, setStats] = useState(null);
+
+  const [events, setEvents] = useState([]);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+  const select = useRef(null);
+  useEffect(() => {
+    getEvents().then(data => setEvents(data));
+  }, []);
+
+  return (
+    <Box m="8">
+      <Heading>Trash by event</Heading>
+      <HStack mt="2">
+        <Select placeholder="Select an event" ref={select}>
+          {events.map(event => (
+            <option value={event.id} key={event.id}>
+              {event.name}
+            </option>
+          ))}
+        </Select>
+        <Button
+          onClick={() => {
+            setSelectedEvent(
+              events.filter(event => `${event.id}` === `${select.current.value}`)[0],
+            );
+            getEventStats(select.current.value).then(data => {
+              setStats(data);
+            });
+          }}
+        >
+          View Data
+        </Button>
+      </HStack>
+      {!selectedEvent ? (
+        <Text mt="4">Select an event to view data</Text>
+      ) : (
+        <VolunteerTrashCollectedCard title={selectedEvent.name} amount={stats} />
+      )}
+    </Box>
+  );
+};
+
+const StatsByProfile = () => {
+  const [stats, setStats] = useState(null);
+
+  const [profiles, setProfiles] = useState([]);
+  const [selectedProfile, setSelectedProfile] = useState(null);
+  const select = useRef(null);
+  useEffect(() => {
+    getProfiles().then(data => setProfiles(data));
+  }, []);
+
+  return (
+    <Box m="8">
+      <Heading>Trash by profile</Heading>
+      <HStack mt="2">
+        <Select placeholder="Select a profile" ref={select}>
+          {profiles.map(profile => (
+            <option value={profile.id} key={profile.id}>
+              {profile.first_name} (ID:{profile.id})
+            </option>
+          ))}
+        </Select>
+        <Button
+          onClick={() => {
+            setSelectedProfile(profiles.filter(profile => profile.id === select.current.value)[0]);
+            getVolunteerStats(select.current.value).then(data => {
+              setStats(data);
+            });
+          }}
+        >
+          View Data
+        </Button>
+      </HStack>
+      {!selectedProfile ? (
+        <Text mt="4">Select a profile to view data</Text>
+      ) : (
+        <VolunteerTrashCollectedCard title={selectedProfile.first_name} amount={stats} />
+      )}
+    </Box>
+  );
+};
+
+const VolunteerTrashCollectedCard = ({ title, amount }) => {
+  return (
+    <Card my="4">
       <CardBody>
         <Text>
-          All events
+          {title}
           <br />
           <br />
           total trash:
           <br />
-          {stats} pounds
+          {amount} pounds
         </Text>
       </CardBody>
     </Card>
   );
 };
 
-const getVolunteerData = async () => {
-  const resp = await Backend.get('/stats');
+VolunteerTrashCollectedCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  amount: PropTypes.number.isRequired,
+};
+
+const getStatsData = async dataId => {
+  const resp = await Backend.get(dataId ? `/stats/${dataId}` : '/stats');
+  return resp.data;
+};
+
+const getEventStats = async dataId => {
+  const resp = await Backend.get(`/stats/event/${dataId}`);
+  return resp.data;
+};
+
+const getVolunteerStats = async dataId => {
+  const resp = await Backend.get(`/stats/volunteer/${dataId}`);
+  return resp.data;
+};
+
+const getEvents = async () => {
+  const resp = await Backend.get('/events');
+  console.log(resp.data);
+  return resp.data;
+};
+
+const getProfiles = async () => {
+  const resp = await Backend.get('/profiles');
   return resp.data;
 };
 

--- a/src/pages/DummyStatsPage.jsx
+++ b/src/pages/DummyStatsPage.jsx
@@ -1,7 +1,31 @@
-import { Text } from '@chakra-ui/react';
+import { Card, CardBody, Text } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import Backend from '../utils/utils';
 
 const DummyStatsPage = () => {
-  return <Text>Placeholder for Stats Page</Text>;
+  const [stats, setStats] = useState(null);
+  useEffect(() => {
+    getVolunteerData().then(data => setStats(data));
+  }, []);
+  return (
+    <Card m="8">
+      <CardBody>
+        <Text>
+          All events
+          <br />
+          <br />
+          total trash:
+          <br />
+          {stats} pounds
+        </Text>
+      </CardBody>
+    </Card>
+  );
+};
+
+const getVolunteerData = async () => {
+  const resp = await Backend.get('/stats');
+  return resp.data;
 };
 
 export default DummyStatsPage;

--- a/src/pages/DummyStatsPage.jsx
+++ b/src/pages/DummyStatsPage.jsx
@@ -128,8 +128,8 @@ const VolunteerTrashCollectedCard = ({ title, amount }) => {
 };
 
 VolunteerTrashCollectedCard.propTypes = {
-  title: PropTypes.string.isRequired,
-  amount: PropTypes.number.isRequired,
+  title: PropTypes.string,
+  amount: PropTypes.string,
 };
 
 const getStatsData = async dataId => {


### PR DESCRIPTION
Authors: @phillipcutter @KatyH820 

### What does this PR contain?

1. A Chakra card to display the total amount of trash collected across all projects (using `/stats/` data endpoint)
2. A Chakra card and form to allow the user to select an event and view the amount of trash collected in a project (using `/stats/event/:eventId` endpoint)
3. A Chakra card and form to allow the user to select a profile and view the amount of trash collected by that person (using `/stats/volunteer/:volunteerId` endpoint)

### How did you test these changes?

I tested these changes by running the backend locally using the branch with the endpoints created by Katy ([See this PR](https://github.com/ctc-uci/stand-up-to-trash-backend/pull/25)), and tested viewing stats for all projects, by each project, and by each person.

### Attach images (if applicable)

Initial page on load:
![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/6702a691-e745-47a3-9e8c-b10f2a344246)

Trash by event dropdown
<img width="886" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/db38a261-e422-4ee5-b62b-d55798988506">

Trash by profile dropdown
<img width="874" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/078318e0-d079-4e4b-bcf1-23a5ab1e00e1">

Trash stats for all events, UCI event, and Billy profile:
![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/b0e2a15e-f4c4-4a3e-99d1-498a5153cc3f)


Closes #21 