### PR TITLE
Feat: Link Firebase Authentication to Volunteers Table

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,6 +3,7 @@ import {
   FormControl,
   FormErrorMessage,
   FormLabel,
+  HStack,
   Input,
   Modal,
   ModalBody,
@@ -24,6 +25,7 @@ import {
   logInWithEmailAndPassWord,
   sendResetPasswordPrompt,
 } from '../utils/firebaseAuthUtils';
+import Backend from '../utils/utils';
 
 const Login = () => {
   return (
@@ -43,6 +45,8 @@ const signinSchema = yup.object({
 });
 
 const signupSchema = yup.object({
+  firstName: yup.string().required("Please enter your first name"),
+  lastName: yup.string().required("Please enter your last name"),
   email: yup.string().email().required('Please enter your email address'),
   password: yup
     .string()
@@ -146,10 +150,11 @@ const CreateAccount = () => {
   const navigate = useNavigate();
 
   const onSubmit = async event => {
-    const { email, password } = event;
+    const { email, password, firstName, lastName } = event;
 
     try {
       await createUserInFirebase(email, password, '/successful-login', navigate);
+      await createVolunteerRow({id: email, email, firstName, lastName});
 
       toast.closeAll();
 
@@ -188,6 +193,18 @@ const CreateAccount = () => {
           <ModalCloseButton />
           <ModalBody>
             <form onSubmit={handleSubmit(onSubmit)}>
+              <HStack>
+              <FormControl isInvalid={errors.firstName}>
+                <FormLabel>First Name</FormLabel>
+                <Input type="text" {...register('firstName')} />
+                {errors.firstName && <FormErrorMessage>{errors.firstName?.message}</FormErrorMessage>}
+              </FormControl>
+              <FormControl isInvalid={errors.lastName}>
+                <FormLabel>Last Name</FormLabel>
+                <Input type="text" {...register('lastName')} />
+                {errors.lastName && <FormErrorMessage>{errors.lastName?.message}</FormErrorMessage>}
+              </FormControl>
+              </HStack>
               <FormControl isInvalid={errors.email}>
                 <FormLabel>Email address</FormLabel>
                 <Input type="email" {...register('email')} />
@@ -220,6 +237,16 @@ const CreateAccount = () => {
       </Modal>
     </>
   );
+};
+
+const createVolunteerRow = async ({ id, email, firstName, lastName }) => {
+  const response = await Backend.post("/profiles", {
+    id: id,
+    email: email,
+    first_name: firstName,
+    last_name: lastName,
+  });
+  return response;
 };
 
 const ForgotPasswordButton = () => {


### PR DESCRIPTION
Authors: @phillipcutter @KatyH820 

### What does this PR contain?

1. Added first & last name fields to the create account form, along with validation requiring the fields be entered
2. Added a POST call to /profiles to create a new volunteer record when a user creates their account
    - Note that only the email, first name, and last name are passed. The email is used as the primary key (ID).

### How did you test these changes?

We tested these changes by running the backend locally, and tested creating an account without a first and/or last name to ensure validation worked, then ensured the `/profiles` endpoint was being called to create a new volunteer record in the database when a user creates an account.

### Attach images (if applicable)

New create account form:
<img width="544" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/95d79d1c-3e8b-46f1-8fbe-bdb279c61cc1">

No first name filled out:
<img width="474" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/7f3061df-dee2-4cc1-9d83-381e3aa3f750">

No last name filled out:
<img width="472" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/d7271668-1717-4ea8-93ac-50ccba12a99d">


Closes #30 