### PR TITLE
Event Dashboard Match Design and Flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
@@ -28,6 +29,7 @@
     "react-csv": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-hook-form": "7.37.0",
+    "react-icons": "^5.0.1",
     "react-pdf": "^7.7.0",
     "react-router-dom": "^6.21.1",
     "vite-plugin-top-level-await": "^1.4.1",

--- a/src/components/DummyEvents/AllData.jsx
+++ b/src/components/DummyEvents/AllData.jsx
@@ -1,0 +1,34 @@
+import { Box, Heading, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+import TotalParticipantsCard from './TotalParticipants';
+
+const AllData = () => {
+  const totalP = 23;
+  const totalT = 23;
+  return (
+    <Box maxWidth="434px" width="100%" maxHeight="260px" height="260px">
+      <Box my="13px">
+        <Heading>all data</Heading>
+        <Tabs variant="soft-rounded" colorScheme="green">
+          <TabList>
+            <Tab>weekly</Tab>
+            <Tab>monthly</Tab>
+            <Tab>yearly</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel p="0">
+              <TotalParticipantsCard totalParticipants={totalP} totalTrash={totalT} />
+            </TabPanel>
+            <TabPanel p="0">
+              <TotalParticipantsCard totalParticipants={totalP} totalTrash={totalT} />
+            </TabPanel>
+            <TabPanel p="0">
+              <TotalParticipantsCard totalParticipants={totalP} totalTrash={totalT} />
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      </Box>
+    </Box>
+  );
+};
+
+export default AllData;

--- a/src/components/DummyEvents/CreateEventButton.jsx
+++ b/src/components/DummyEvents/CreateEventButton.jsx
@@ -1,0 +1,122 @@
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Textarea,
+  useDisclosure,
+} from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import Backend from '../../utils/utils';
+
+const CreateEventButton = ({ getEvents }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  // These values are placeholders to just test the form
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    location: '',
+    imageUrl: '',
+    date: '2024-01-01',
+    time: '07:00',
+    waiver: '',
+  });
+
+  const handleInputChange = e => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    console.log('FORM DATA: ', formData);
+    try {
+      await Backend.post('/events', formData);
+      console.log('Submitted');
+      setFormData({ name: '', description: '', location: '' });
+      getEvents();
+    } catch (e) {
+      console.log('Error posting', e);
+    }
+  };
+
+  return (
+    <>
+      <Button style={{ backgroundColor: '#95D497', borderRadius: '0px' }} onClick={onOpen}>
+        + Create New Event
+      </Button>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Create new event</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <form onSubmit={handleSubmit}>
+              <FormControl isRequired marginTop={10}>
+                <FormLabel marginLeft={10} htmlFor="name">
+                  Name
+                </FormLabel>
+                <Input
+                  marginLeft={10}
+                  id="name"
+                  name="name"
+                  onChange={handleInputChange}
+                  value={formData.name}
+                />
+              </FormControl>
+              <FormControl isRequired>
+                <FormLabel marginLeft={10} htmlFor="description">
+                  Description
+                </FormLabel>
+                <Textarea
+                  id="description"
+                  name="description"
+                  onChange={handleInputChange}
+                  value={formData.description}
+                  marginLeft={10}
+                />
+              </FormControl>
+              <FormControl isRequired>
+                <FormLabel marginLeft={10} htmlFor="location">
+                  Location
+                </FormLabel>
+                <Input
+                  marginLeft={10}
+                  id="location"
+                  name="location"
+                  onChange={handleInputChange}
+                  value={formData.location}
+                />
+              </FormControl>
+              <Button marginLeft={10} type="submit" colorScheme="blue" marginTop={4}>
+                Submit
+              </Button>
+            </form>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3}>
+              Save
+            </Button>
+            <Button onClick={onClose}>Cancel</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+CreateEventButton.propTypes = {
+  getEvents: PropTypes.func.isRequired,
+};
+
+export default CreateEventButton;

--- a/src/components/DummyEvents/DeleteEventsModal.jsx
+++ b/src/components/DummyEvents/DeleteEventsModal.jsx
@@ -29,10 +29,10 @@ const DeleteEventsModal = ({ isOpen, onClose, events, confirmDelete }) => {
             </UnorderedList>
           </ModalBody>
           <ModalFooter>
-            <Button colorScheme="red" mr={3} onClick={confirmDelete}>
+            <Button onClick={onClose}>Cancel</Button>
+            <Button colorScheme="red" ml={3} onClick={confirmDelete}>
               Permanently Delete
             </Button>
-            <Button onClick={onClose}>Cancel</Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/components/DummyEvents/DeleteEventsModal.jsx
+++ b/src/components/DummyEvents/DeleteEventsModal.jsx
@@ -1,0 +1,50 @@
+import {
+  Button,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  UnorderedList,
+} from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+
+const DeleteEventsModal = ({ isOpen, onClose, events, confirmDelete }) => {
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Confirm event deletion</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            Are you sure you want to delete these events? This action cannot be undone.
+            <UnorderedList mt="2">
+              {events.map(event => {
+                return <ListItem key={event.id}>{event.name}</ListItem>;
+              })}
+            </UnorderedList>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="red" mr={3} onClick={confirmDelete}>
+              Permanently Delete
+            </Button>
+            <Button onClick={onClose}>Cancel</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+DeleteEventsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  confirmDelete: PropTypes.func.isRequired,
+  events: PropTypes.array.isRequired,
+};
+
+export default DeleteEventsModal;

--- a/src/components/DummyEvents/EventCard.jsx
+++ b/src/components/DummyEvents/EventCard.jsx
@@ -1,0 +1,125 @@
+import {
+  Box,
+  Button,
+  Checkbox,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalOverlay,
+  Spacer,
+  Stack,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+const EventCard = ({
+  id,
+  name,
+  description,
+  location,
+  showSelect,
+  isSelected,
+  handleCheckboxChange,
+}) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <>
+      <Box
+        width="293px"
+        height="250px"
+        boxShadow="0px 4px 4px 0px rgba(0, 0, 0, 0.25)"
+        display="flex"
+        alignItems="center"
+        justifyItems="center"
+        as="a"
+        href="#"
+        onClick={() => (showSelect ? handleCheckboxChange(id) : onOpen())}
+      >
+        {showSelect ? (
+          <Checkbox
+            id={id}
+            marginLeft="10px"
+            marginBottom="200px"
+            style={{ borderRadius: '100px' }}
+            isChecked={isSelected}
+            onChange={() => handleCheckboxChange(id)}
+          />
+        ) : null}
+        <Spacer />
+        <Text fontSize={18} fontWeight={'bold'} textAlign={'center'} m="4">
+          {name}
+        </Text>
+        <Spacer />
+      </Box>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent maxH="660px" maxW="800px" borderRadius="0">
+          <ModalBody p="0">
+            <Box display="flex" flexDir="row" h="660px" w="800px">
+              <Box flexBasis="60%" display="flex" flexDir="column">
+                <Box flexBasis="60%" bg="#D9D9D9" display="flex" alignItems="end" p="2">
+                  <Stack mx="6">
+                    <Heading>{name}</Heading>
+                    <Text>{location}</Text>
+                  </Stack>
+                </Box>
+                <Box
+                  flexBasis="40%"
+                  mx="8"
+                  my="4"
+                  display="flex"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  flexDir="column"
+                >
+                  <Box alignSelf="start">
+                    <Heading fontSize={24}>Event Description</Heading>
+                    <Text fontSize={18}>{description}</Text>
+                  </Box>
+                  <Box>
+                    <Button
+                      color="black"
+                      backgroundColor="rgba(149, 189, 212, 0.71)"
+                      borderRadius="0"
+                      colorScheme={'grey'}
+                      as="a"
+                      href={`/checkin/${id}`}
+                      target="_blank"
+                    >
+                      View More
+                    </Button>
+                  </Box>
+                </Box>
+              </Box>
+              <Box
+                flexBasis="40%"
+                bg="rgba(217, 217, 217, 0.40)"
+                display="flex"
+                justifyItems={'end'}
+                alignItems={'start'}
+              >
+                <ModalCloseButton />
+              </Box>
+            </Box>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+EventCard.propTypes = {
+  id: PropTypes.number,
+  name: PropTypes.string,
+  description: PropTypes.string,
+  location: PropTypes.string,
+  showSelect: PropTypes.bool,
+  isSelected: PropTypes.bool,
+  handleCheckboxChange: PropTypes.func,
+};
+
+export default EventCard;

--- a/src/components/DummyEvents/RecentEventsCard.jsx
+++ b/src/components/DummyEvents/RecentEventsCard.jsx
@@ -1,0 +1,48 @@
+import { Box, Heading, Icon, Text } from '@chakra-ui/react';
+import { BsArrowDownRight, BsArrowUpRight } from 'react-icons/bs';
+const RecentEventsCard = () => {
+  return (
+    <Box backgroundColor="#F3F3F3" maxWidth="434px" width="100%" height="280px">
+      <Box my="13px" mx="25px">
+        <Heading>recent event</Heading>
+
+        <Box mt="12px" mx="11px" display="flex" flexDir="row" gap="14px">
+          <Box backgroundColor="#E7E7E7" w="170px" h="170px">
+            <Box
+              mx="13px"
+              display="flex"
+              flexDir="column"
+              alignContent="center"
+              justifyContent="center"
+              gap="25px"
+              h="100%"
+            >
+              <Text>total participants</Text>
+              <span>
+                <Icon as={BsArrowUpRight} /> + 23%
+              </span>
+            </Box>
+          </Box>
+          <Box backgroundColor="#E7E7E7" w="170px" h="170px">
+            <Box
+              mx="13px"
+              display="flex"
+              flexDir="column"
+              alignContent="center"
+              justifyContent="center"
+              gap="25px"
+              h="100%"
+            >
+              <Text>total trash</Text>
+              <span>
+                <Icon as={BsArrowDownRight} /> - 3%
+              </span>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default RecentEventsCard;

--- a/src/components/DummyEvents/Sidebar.jsx
+++ b/src/components/DummyEvents/Sidebar.jsx
@@ -1,0 +1,64 @@
+import { Box } from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+
+const Sidebar = ({ children }) => {
+  return (
+    <>
+      <Box position="sticky" top="0" width="74x" float="left" style={{ shapeOutside: 'inset(50%' }}>
+        <Box
+          h="100vh"
+          backgroundColor="#D9D9D9"
+          flex="0 0 73px"
+          display="flex"
+          flexDir="column"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Box display="flex" flexDir="column" p="10px" as="a" href="/">
+            {/* Top sidebar items */}
+            <svg
+              width="55"
+              height="55"
+              viewBox="0 0 55 55"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M22.9166 45.8333V32.0833H32.0833V45.8333H43.5416V27.5H50.4166L27.5 6.875L4.58331 27.5H11.4583V45.8333H22.9166Z"
+                fill="black"
+              />
+            </svg>
+          </Box>
+          <Box
+            display="flex"
+            flexDir="column"
+            p="10px"
+            as="a"
+            href="#"
+            onClick={() => {
+              alert("I don't do anything yet");
+            }}
+          >
+            {/* Bottom sidebar items */}
+            <svg
+              width="55"
+              height="55"
+              viewBox="0 0 55 55"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle cx="27.5" cy="27.5" r="27.5" fill="#404040" />
+            </svg>
+          </Box>
+        </Box>
+      </Box>
+      <Box ml="74px">{children}</Box>
+    </>
+  );
+};
+
+Sidebar.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Sidebar;

--- a/src/components/DummyEvents/TotalParticipants.jsx
+++ b/src/components/DummyEvents/TotalParticipants.jsx
@@ -1,0 +1,50 @@
+import { Box, Icon, Text } from '@chakra-ui/react';
+import PropTypes from 'prop-types';
+import { BsArrowDownRight, BsArrowUpRight } from 'react-icons/bs';
+const TotalParticipantsCard = ({ totalParticipants, totalTrash }) => {
+  return (
+    <>
+      <Box mt="12px" mx="11px" display="flex" flexDir="row" gap="38px" alignContent="left">
+        <Box backgroundColor="#E7E7E7" w="200px" h="173px">
+          <Box
+            mx="13px"
+            display="flex"
+            flexDir="column"
+            alignContent="center"
+            justifyContent="center"
+            gap="25px"
+            h="100%"
+          >
+            <Text>total participants</Text>
+            <span>
+              <Icon as={BsArrowUpRight} /> + {totalParticipants}%
+            </span>
+          </Box>
+        </Box>
+        <Box backgroundColor="#E7E7E7" w="200px" h="170px">
+          <Box
+            mx="13px"
+            display="flex"
+            flexDir="column"
+            alignContent="center"
+            justifyContent="center"
+            gap="25px"
+            h="100%"
+          >
+            <Text>total trash</Text>
+            <span>
+              <Icon as={BsArrowDownRight} /> - {totalTrash}%
+            </span>
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+TotalParticipantsCard.propTypes = {
+  totalParticipants: PropTypes.number,
+  totalTrash: PropTypes.number,
+};
+
+export default TotalParticipantsCard;

--- a/src/pages/DummyEvents.jsx
+++ b/src/pages/DummyEvents.jsx
@@ -127,14 +127,13 @@ const DummyEvents = () => {
   const EventCard = ({id, name, description, location}) => {
     const { isOpen, onOpen, onClose } = useDisclosure();
 
-    return (<>
+    return (
+    <>
       <Box width="293px" height="250px" boxShadow="0px 4px 4px 0px rgba(0, 0, 0, 0.25)" display="flex" alignItems="center" justifyItems="center" as="a" href="#" onClick={onOpen}>
-        {showSelect ? <Checkbox id={id} isChecked={selectedEvents.includes(id)} onChange={() => handleCheckboxChange(id)}/> : null}
-        <Box>
-          <Spacer/>
-          <Text fontSize={18} fontWeight={"bold"} textAlign={"center"} m="4">{name}</Text>
-          <Spacer/>
-        </Box>
+        {showSelect ? <Checkbox id={id} marginLeft="10px" marginBottom="30vh" style={{ borderRadius: "100px" }} isChecked={selectedEvents.includes(id)} onChange={() => handleCheckboxChange(id)}/> : null}
+        <Spacer/>
+        <Text fontSize={18} fontWeight={"bold"} textAlign={"center"} m="4">{name}</Text>
+        <Spacer/>
       </Box>
 
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -381,7 +380,7 @@ const DummyEvents = () => {
   const SelectButton = () => {
     return (
       <>
-        <Button style={{ backgroundColor: "white" }} onClick={() => handleSelectButton()}>Select</Button>
+        <Button style={{ backgroundColor: "white" }} onClick={() => handleSelectButton()} marginRight="13vw">Select</Button>
       </>
     )
   };
@@ -389,7 +388,7 @@ const DummyEvents = () => {
   const DeleteButton = ( {id} ) => {
     return (
       <>
-        <Button style={{ backgroundColor: "#FF6666", borderRadius: "0px" }} onClick={() => deleteEvents(id)}>Delete Event(s)</Button>
+        <Button style={{ backgroundColor: "#FF6666", borderRadius: "0px" }} onClick={() => deleteEvents(id)} marginRight="13vw">Delete Event(s)</Button>
       </>
     )
   };

--- a/src/pages/DummyEvents.jsx
+++ b/src/pages/DummyEvents.jsx
@@ -2,23 +2,47 @@ import { useEffect, useState } from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
 import {
   Button,
+  Box,
   Stack,
   StackDivider,
+  Divider,
+  Spacer,
+  Grid,
+  GridItem,
   Card,
+  Icon,
+  Heading,
   CardBody,
   Text,
   FormControl,
   FormLabel,
   Input,
   Textarea,
+  Tabs,
+  TabList, 
+  TabPanels,
+  Tab,
+  TabPanel,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  useDisclosure,
 } from '@chakra-ui/react';
+import { TriangleUpIcon, TriangleDownIcon, SmallAddIcon } from '@chakra-ui/icons';
+import { BsArrowUpRight, BsArrowDownRight, BsBoxArrowDownRight, BsPcHorizontal } from "react-icons/bs";
 import Backend from '../utils/utils';
+import PropTypes from 'prop-types';
+
 
 const DummyEvents = () => {
   const [events, setEvents] = useState([]);
   const [selectEvent, setSelectEvent] = useState(null);
   const [eventId, setEventId] = useState('');
-  const [showEvents, setShowEvents] = useState(false);
+  const [showEvents, setShowEvents] = useState(true);
 
   const [formData, setFormData] = useState({ name: '', description: '', location: '' });
 
@@ -77,15 +101,82 @@ const DummyEvents = () => {
     }
   };
 
-  const showEvent = () => {
-    setShowEvents(true);
-    if (eventId) {
-      getEventId();
-    }
-  };
+  // const showEvent = () => {
+  //   setShowEvents(true);
+  //   if (eventId) {
+  //     getEventId();
+  //   }
+  // };
+
+  const EventCard = ({id, name, description, location}) => {
+    const { isOpen, onOpen, onClose } = useDisclosure();
+
+    return (<>
+      <Box width="250px" height="250px" boxShadow="0px 4px 4px 0px rgba(0, 0, 0, 0.25)" display="flex" alignItems="center" justifyItems="center" as="a" href="#" onClick={onOpen}>
+        <Spacer/>
+        <Text fontSize={18} fontWeight={"bold"} textAlign={"center"} m="4">{name}</Text>
+        <Spacer/>
+      </Box>
+
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay/>
+      <ModalContent maxH="660px" maxW="800px" borderRadius="0">
+        <ModalBody p="0">
+          <Box display="flex" flexDir="row" h="660px" w="800px">
+            <Box flexBasis="60%" display="flex" flexDir="column">
+              <Box flexBasis="60%" bg="#D9D9D9" display="flex" alignItems="end" p="2">
+                <Stack mx="6">
+                  <Heading>{name}</Heading>
+                  <Text>{ location }</Text>
+                </Stack>
+              </Box>
+              <Box flexBasis="40%" mx="8" my="4" display="flex" justifyContent="space-between" alignItems="center" flexDir="column">
+                <Box alignSelf="start">
+                  <Heading fontSize={24}>Event Description</Heading>
+                  <Text fontSize={18}>
+                    {description}
+                  </Text>
+                </Box>
+                <Box>
+                  <Button color="black" backgroundColor="rgba(149, 189, 212, 0.71)" borderRadius="0" colorScheme={"grey"} as="a" href={`/checkin/${id}`} target="_blank">View More</Button>
+                </Box>
+              </Box>
+            </Box>
+            <Box flexBasis="40%" bg="rgba(217, 217, 217, 0.40)" display="flex" justifyItems={"end"} alignItems={"start"}> 
+              <ModalCloseButton/>
+            </Box>
+          </Box>
+        </ModalBody>
+        {/* <ModalCloseButton />
+        <ModalBody>
+          
+        </ModalBody> */}
+
+      </ModalContent>
+    </Modal>
+      {/* <Card >
+        <CardBody>
+          <Stack spacing={4}>
+            <Text>Event ID: {id}</Text>
+            <Text>Name: {name}</Text>
+            <Text>Description: {description}</Text>
+            <Text>Location: {location}</Text>
+            <Button
+              marginRight={'auto'}
+              colorScheme="red"
+              onClick={() => deleteEvents(id)}
+            >
+              Delete
+            </Button>
+          </Stack>
+        </CardBody>
+      </Card> */}
+      </>
+    )
+  }
 
   const eventCards = (
-    <Stack divider={<StackDivider />} spacing="4">
+    <Grid templateColumns='repeat(3, 1fr)' gap={6}>
       {selectEvent ? (
         <Card key={selectEvent.id}>
           <CardBody>
@@ -106,26 +197,12 @@ const DummyEvents = () => {
         </Card>
       ) : (
         events.map(element => (
-          <Card key={element.id}>
-            <CardBody>
-              <Stack spacing={4}>
-                <Text>Event ID: {element.id}</Text>
-                <Text>Name: {element.name}</Text>
-                <Text>Description: {element.description}</Text>
-                <Text>Location: {element.location}</Text>
-                <Button
-                  marginRight={'auto'}
-                  colorScheme="red"
-                  onClick={() => deleteEvents(element.id)}
-                >
-                  Delete
-                </Button>
-              </Stack>
-            </CardBody>
-          </Card>
+          <GridItem key={element.id} >
+            <EventCard {...element}/>
+          </GridItem>
         ))
       )}
-    </Stack>
+    </Grid>
   );
 
   useEffect(() => {
@@ -133,9 +210,143 @@ const DummyEvents = () => {
     // getEventId(eventId);
   }, []);
 
+  const Sidebar = ({ children }) => {
+    // const [sidebarHeight, setSidebarHeight] = useState("100vh");
+
+    // const updateHeight = () => {
+    //   setSidebarHeight(Math.max(document.body.scrollHeight, window.innerHeight) + "px");
+    // }
+
+    // new ResizeObserver(updateHeight);
+    // useEffect(updateHeight, []);
+
+    return (
+      <>
+        <Box position="sticky" top="0" width="74x" float="left" style={{shapeOutside: "inset(50%"}}>
+          <Box h="100vh" backgroundColor="#D9D9D9" flex="0 0 73px" display="flex" flexDir="column" justifyContent="space-between" alignItems="center">
+            <Box display="flex" flexDir="column" p="10px" as="a" href="/">
+              {/* Top sidebar items */}
+              <svg width="55" height="55" viewBox="0 0 55 55" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M22.9166 45.8333V32.0833H32.0833V45.8333H43.5416V27.5H50.4166L27.5 6.875L4.58331 27.5H11.4583V45.8333H22.9166Z" fill="black"/>
+              </svg>
+            </Box>
+            <Box display="flex" flexDir="column" p="10px" as="a" href="#" onClick={() => {alert("I don't do anything yet")}}>
+              {/* Bottom sidebar items */}
+              <svg width="55" height="55" viewBox="0 0 55 55" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="27.5" cy="27.5" r="27.5" fill="#404040"/>
+              </svg>
+            </Box>
+          </Box>
+        </Box> 
+        <Box ml="74px">
+          {children}
+        </Box>
+      </>
+    )
+  }
+
+  Sidebar.propTypes = {
+    children: PropTypes.node.isRequired
+  };
+
+  const RecentEventsCard = () => {
+    return (
+      <Box backgroundColor="#F3F3F3" maxWidth="434px" width="100%" maxHeight="260px" height="260px">
+        <Box my="13px" mx="25px">
+          <Heading>recent event</Heading>
+          
+          <Box mt="12px" mx="11px" display="flex" flexDir="row" gap="14px">
+            <Box backgroundColor="#E7E7E7" w="170px" h="170px">
+              <Box mx="13px" display="flex" flexDir="column" alignContent="center" justifyContent="center" gap="25px" h="100%">
+                <Text>total participants</Text>
+                <span>
+                <Icon as={BsArrowUpRight} /> + 23%
+                </span>
+              </Box>
+            </Box>
+            <Box backgroundColor="#E7E7E7" w="170px" h="170px">
+            <Box mx="13px" display="flex" flexDir="column" alignContent="center" justifyContent="center" gap="25px" h="100%">
+                <Text>total trash</Text>
+                <span>
+                  <Icon as={BsArrowDownRight} /> - 3%
+                </span>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  const TotalParticipantsCard = ( {totalParticipants, totalTrash} ) => {
+    return (
+      <>
+        <Box mt="12px" mx="11px" display="flex" flexDir="row" gap="38px" alignContent="left">
+          <Box backgroundColor="#E7E7E7" w="200px" h="173px">
+          <Box mx="13px" display="flex" flexDir="column" alignContent="center" justifyContent="center" gap="25px" h="100%">
+                <Text>total participants</Text>
+                <span>
+                <Icon as={BsArrowUpRight} /> + {totalParticipants}%
+                </span>
+              </Box>
+            </Box>
+            <Box backgroundColor="#E7E7E7" w="200px" h="170px">
+            <Box mx="13px" display="flex" flexDir="column" alignContent="center" justifyContent="center" gap="25px" h="100%">
+                <Text>total trash</Text>
+                <span>
+                  <Icon as={BsArrowDownRight} /> - {totalTrash}%
+                </span>
+              </Box>
+            </Box>
+        </Box>
+      </>
+    )
+  };
+  
+  TotalParticipantsCard.propTypes = {
+    totalParticipants: PropTypes.integer,
+    totalTrash: PropTypes.integer,
+  };
+
+  const AllData = () => {
+    const totalP = 23;
+    const totalT = 23;
+    return (
+      <Box maxWidth="434px" width="100%" maxHeight="260px" height="260px">
+        <Box my="13px">
+        <Heading>all data</Heading>
+          <Tabs variant='soft-rounded' colorScheme='green'>
+            <TabList>
+              <Tab>weekly</Tab>
+              <Tab>monthly</Tab>
+              <Tab>yearly</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel p="0">
+                <TotalParticipantsCard totalParticipants={totalP} totalTrash={totalT} />
+              </TabPanel>
+              <TabPanel p="0">
+                <TotalParticipantsCard totalParticipants={totalP} totalTrash={totalT} />
+              </TabPanel>
+              <TabPanel p="0">
+                <TotalParticipantsCard  totalParticipants={totalP} totalTrash={totalT}/>
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Box>
+      </Box>
+    )
+  };
+
   return (
-    <ChakraProvider>
-      <form onSubmit={handleSubmit}>
+    <Sidebar>
+    <Box mx="156px" pt="30px" justifyContent="flex-start">
+      <Box display="flex" flexDirection="row" gap="83px" justifyContent="center" alignItems={"left"}>
+        <RecentEventsCard/>
+        <AllData/>
+      </Box>
+      
+      {/* <form onSubmit={handleSubmit}>
         <FormControl isRequired marginTop={10}>
           <FormLabel marginLeft={10} htmlFor="name">
             Name
@@ -175,25 +386,41 @@ const DummyEvents = () => {
         <Button marginLeft={10} type="submit" colorScheme="blue" marginTop={4}>
           Submit
         </Button>
-      </form>
-      <Stack align="center" marginTop={10} marginBottom={10} flexDirection={'row'} spacing={4}>
+      </form> */}
+      <Box justifyContent="space-between" display="flex" flex-direction="column">
+          <Box justifyContent="space-between" display="flex" flex-direction="row">
+            <Box>
+              <Button style={{ backgroundColor: "#95D497", borderRadius: '0px' }}>+ Create New Event</Button>
+            </Box>
+            <Box alignItems="left">
+              <Button style={{ backgroundColor: "white" }}>Select</Button>
+            </Box>
+          </Box>
+          <Box display="flex" flex-direction="space-between">
+              <Box marginTop="3vh">
+                { eventCards }
+              </Box>
+          </Box>
+      </Box>
+      {/* <Stack align="center" marginTop={10} marginBottom={10} flexDirection={'row'} spacing={4}>
         <Input
           width={'auto'}
           marginLeft={10}
           id="eventid"
           name="eventid"
           onChange={handleInputChange}
-          // value={eventId}
+          value={eventId}
         />
         <Button size="md" colorScheme="linkedin" onClick={showEvent}>
           Show Events
         </Button>
-        <Button size="md" colorSchem="yellow" onClick={() => setShowEvents(false)}>
+        <Button size="md" colorScheme="yellow" onClick={() => setShowEvents(false)}>
           Unshow Events
         </Button>
       </Stack>
-      {showEvents ? eventCards : null}
-    </ChakraProvider>
+      {showEvents ? eventCards : null} */}
+      </Box>
+    </Sidebar>
   );
 };
 

--- a/src/pages/DummyEvents.jsx
+++ b/src/pages/DummyEvents.jsx
@@ -6,11 +6,9 @@ import {
   Spacer,
   Grid,
   GridItem,
-  Card,
   Checkbox,
   Icon,
   Heading,
-  CardBody,
   Text,
   FormControl,
   FormLabel,
@@ -34,17 +32,113 @@ import { BsArrowUpRight, BsArrowDownRight } from "react-icons/bs";
 import Backend from '../utils/utils';
 import PropTypes from 'prop-types';
 
+const CreateButton = ({ getEvents }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const [formData, setFormData] = useState({ name: '', description: '', location: '' });
+  // const [selectEvent, setSelectEvent] = useState(null);
+
+  const handleInputChange = e => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+    if (name == 'eventid') {
+      // if (value == '') {
+      //   setSelectEvent(null);
+      // }
+      // setEventId(value);
+    }
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    console.log('FORM DATA: ', formData);
+    try {
+      await Backend.post('/events', formData);
+      console.log('Submitted');
+      setFormData({ name: '', description: '', location: '' });
+      getEvents();
+    } catch (e) {
+      console.log('Error posting', e);
+    }
+  };
+
+
+  return (
+    <>
+      <Button style={{ backgroundColor: "#95D497", borderRadius: '0px' }} onClick={onOpen}>+ Create New Event</Button>
+      <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Create new event</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+        <form onSubmit={handleSubmit}>
+          <FormControl isRequired marginTop={10}>
+            <FormLabel marginLeft={10} htmlFor="name">
+              Name
+            </FormLabel>
+            <Input
+              marginLeft={10}
+              id="name"
+              name="name"
+              onChange={handleInputChange}
+              value={formData.name}
+            />
+          </FormControl>
+          <FormControl isRequired>
+            <FormLabel marginLeft={10} htmlFor="description">
+              Description
+            </FormLabel>
+            <Textarea
+              id="description"
+              name="description"
+              onChange={handleInputChange}
+              value={formData.description}
+              marginLeft={10}
+            />
+          </FormControl>
+          <FormControl isRequired>
+            <FormLabel marginLeft={10} htmlFor="location">
+              Location
+            </FormLabel>
+            <Input
+              marginLeft={10}
+              id="location"
+              name="location"
+              onChange={handleInputChange}
+              value={formData.location}
+            />
+          </FormControl>
+          <Button marginLeft={10} type="submit" colorScheme="blue" marginTop={4}>
+            Submit
+          </Button>
+        </form>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button colorScheme='blue' mr={3}>
+            Save
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+    </>
+  )
+};
+
+CreateButton.propTypes = {
+  getEvents: PropTypes.func.isRequired
+};
 
 const DummyEvents = () => {
   const [events, setEvents] = useState([]);
-  const [selectEvent, setSelectEvent] = useState(null);
   // const [eventId, setEventId] = useState('');
   // const [showEvents, setShowEvents] = useState(true);
   const [showSelect, setShowSelect] = useState(false);
   const [isSelectButton, setIsSelectButton] = useState(true);
   const [isCreateButton, setIsCreateButton] = useState(true); // toggle between create event button and deselect button
   const [selectedEvents, setSelectedEvents] = useState([]);
-  const [formData, setFormData] = useState({ name: '', description: '', location: '' });
 
   const getEvents = async () => {
     try {
@@ -79,30 +173,6 @@ const DummyEvents = () => {
     }
   };
 
-  const handleInputChange = e => {
-    const { name, value } = e.target;
-    setFormData({ ...formData, [name]: value });
-    if (name == 'eventid') {
-      if (value == '') {
-        setSelectEvent(null);
-      }
-      // setEventId(value);
-    }
-  };
-
-  const handleSubmit = async e => {
-    e.preventDefault();
-    console.log('FORM DATA: ', formData);
-    try {
-      await Backend.post('/events', formData);
-      console.log('Submitted');
-      setFormData({ name: '', description: '', location: '' });
-      getEvents();
-    } catch (e) {
-      console.log('Error posting', e);
-    }
-  };
-
   // const showEvent = () => {
   //   setShowEvents(true);
   //   if (eventId) {
@@ -130,7 +200,7 @@ const DummyEvents = () => {
     return (
     <>
       <Box width="293px" height="250px" boxShadow="0px 4px 4px 0px rgba(0, 0, 0, 0.25)" display="flex" alignItems="center" justifyItems="center" as="a" href="#" onClick={onOpen}>
-        {showSelect ? <Checkbox id={id} marginLeft="10px" marginBottom="30vh" style={{ borderRadius: "100px" }} isChecked={selectedEvents.includes(id)} onChange={() => handleCheckboxChange(id)}/> : null}
+        {showSelect ? <Checkbox id={id} marginLeft="10px" marginBottom="200px" style={{ borderRadius: "100px" }} isChecked={selectedEvents.includes(id)} onChange={() => handleCheckboxChange(id)}/> : null}
         <Spacer/>
         <Text fontSize={18} fontWeight={"bold"} textAlign={"center"} m="4">{name}</Text>
         <Spacer/>
@@ -195,7 +265,7 @@ const DummyEvents = () => {
 
   
   EventCard.propTypes = {
-    id: PropTypes.integer,
+    id: PropTypes.number,
     name: PropTypes.string,
     description: PropTypes.string,
     location: PropTypes.string
@@ -203,31 +273,33 @@ const DummyEvents = () => {
 
   const eventCards = (
     <Grid templateColumns='repeat(3, 1fr)' gap={6}>
-      {selectEvent ? (
-        <Card key={selectEvent.id}>
-          <CardBody>
-            <Stack spacing={4}>
-              <Text>Event ID: {selectEvent.id}</Text>
-              <Text>Name: {selectEvent.name}</Text>
-              <Text>Description: {selectEvent.description}</Text>
-              <Text>Location: {selectEvent.location}</Text>
-              <Button
-                marginRight={'auto'}
-                colorScheme="red"
-                onClick={() => deleteEvents(selectEvent.id)}
-              >
-                Delete
-              </Button>
-            </Stack>
-          </CardBody>
-        </Card>
-      ) : (
+       {
+      //   selectEvent ? (
+      //    <Card key={selectEvent.id}>
+      //      <CardBody>
+      //        <Stack spacing={4}>
+      //          <Text>Event ID: {selectEvent.id}</Text>
+      //          <Text>Name: {selectEvent.name}</Text>
+      //          <Text>Description: {selectEvent.description}</Text>
+      //          <Text>Location: {selectEvent.location}</Text>
+      //          <Button
+      //            marginRight={'auto'}
+      //            colorScheme="red"
+      //            onClick={() => deleteEvents(selectEvent.id)}
+      //          >
+      //            Delete
+      //          </Button>
+      //        </Stack>
+      //      </CardBody>
+      //    </Card>
+      //  ) : (
         events.map(element => (
           <GridItem key={element.id} >
             <EventCard {...element}/>
           </GridItem>
         ))
-      )}
+      //  )
+    }
     </Grid>
   );
 
@@ -277,7 +349,7 @@ const DummyEvents = () => {
 
   const RecentEventsCard = () => {
     return (
-      <Box backgroundColor="#F3F3F3" maxWidth="434px" width="100%" maxHeight="260px" height="260px">
+      <Box backgroundColor="#F3F3F3" maxWidth="434px" width="100%" height="280px">
         <Box my="13px" mx="25px">
           <Heading>recent event</Heading>
           
@@ -330,8 +402,8 @@ const DummyEvents = () => {
   };
   
   TotalParticipantsCard.propTypes = {
-    totalParticipants: PropTypes.integer,
-    totalTrash: PropTypes.integer,
+    totalParticipants: PropTypes.number,
+    totalTrash: PropTypes.number,
   };
 
   const AllData = () => {
@@ -380,7 +452,7 @@ const DummyEvents = () => {
   const SelectButton = () => {
     return (
       <>
-        <Button style={{ backgroundColor: "white" }} onClick={() => handleSelectButton()} marginRight="13vw">Select</Button>
+        <Button style={{ backgroundColor: "white" }} onClick={() => handleSelectButton()}>Select</Button>
       </>
     )
   };
@@ -388,82 +460,14 @@ const DummyEvents = () => {
   const DeleteButton = ( {id} ) => {
     return (
       <>
-        <Button style={{ backgroundColor: "#FF6666", borderRadius: "0px" }} onClick={() => deleteEvents(id)} marginRight="13vw">Delete Event(s)</Button>
+        <Button style={{ backgroundColor: "#FF6666", borderRadius: "0px" }} onClick={() => deleteEvents(id)}>Delete Event(s)</Button>
       </>
     )
   };
 
   DeleteButton.propTypes = {
-    id: PropTypes.integer,
+    id: PropTypes.number,
   }
-
-
-  const CreateButton = () => {
-    const { isOpen, onOpen, onClose } = useDisclosure();
-
-    return (
-      <>
-        <Button style={{ backgroundColor: "#95D497", borderRadius: '0px' }} onClick={onOpen}>+ Create New Event</Button>
-        <Modal isOpen={isOpen} onClose={onClose}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>Create new event</ModalHeader>
-          <ModalCloseButton />
-          <ModalBody pb={6}>
-          <form onSubmit={handleSubmit}>
-            <FormControl isRequired marginTop={10}>
-              <FormLabel marginLeft={10} htmlFor="name">
-                Name
-              </FormLabel>
-              <Input
-                marginLeft={10}
-                id="name"
-                name="name"
-                onChange={handleInputChange}
-                value={formData.name}
-              />
-            </FormControl>
-            <FormControl isRequired>
-              <FormLabel marginLeft={10} htmlFor="description">
-                Description
-              </FormLabel>
-              <Textarea
-                id="description"
-                name="description"
-                onChange={handleInputChange}
-                value={formData.description}
-                marginLeft={10}
-              />
-            </FormControl>
-            <FormControl isRequired>
-              <FormLabel marginLeft={10} htmlFor="location">
-                Location
-              </FormLabel>
-              <Input
-                marginLeft={10}
-                id="location"
-                name="location"
-                onChange={handleInputChange}
-                value={formData.location}
-              />
-            </FormControl>
-            <Button marginLeft={10} type="submit" colorScheme="blue" marginTop={4}>
-              Submit
-            </Button>
-          </form>
-          </ModalBody>
-
-          <ModalFooter>
-            <Button colorScheme='blue' mr={3}>
-              Save
-            </Button>
-            <Button onClick={onClose}>Cancel</Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-      </>
-    )
-  };
 
   const DeselectButton = () => {
     return (
@@ -475,8 +479,8 @@ const DummyEvents = () => {
 
   return (
     <Sidebar>
-    <Box mx="156px" pt="30px" justifyContent="flex-start">
-      <Box height="45vh" display="flex" flexDirection="row" gap="83px" justifyContent="flex-start" alignItems={"left"}>
+    <Box mx="156px" pt="30px" justifyContent="flex-start" display="flex" flexDirection="column">
+      <Box mb="60px" display="flex" flexDirection="row" gap="83px" justifyContent="center" alignItems={"left"}>
         <RecentEventsCard/>
         <AllData/>
       </Box>
@@ -523,17 +527,20 @@ const DummyEvents = () => {
         </Button>
       </form> */}
       <Spacer/>
-      <Box justifyContent="space-between">
+      <Box display="flex" justifyContent={"center"}>
+      <Box justifyContent="space-between" width="930px">
           <Box height="129px" display="flex" flex-direction="row" justifyContent="space-between">
-            {isCreateButton ? <CreateButton /> : <DeselectButton />}
+            {isCreateButton ? <CreateButton getEvents={getEvents} /> : <DeselectButton />}
             {isSelectButton ? <SelectButton /> : <DeleteButton id={32} />}
           </Box>
           <Spacer />
-          <Box display="flex" flex-direction="space-between">
+          <Box display="flex" flex-direction="space-between" justifyContent={"center"}>
               <Box marginTop="3vh">
                 { eventCards }
               </Box>
           </Box>
+      </Box>
+
       </Box>
       {/* <Stack align="center" marginTop={10} marginBottom={10} flexDirection={'row'} spacing={4}>
         <Input

--- a/src/pages/DummyEvents.jsx
+++ b/src/pages/DummyEvents.jsx
@@ -196,7 +196,7 @@ const DummyEvents = () => {
 
   
   EventCard.propTypes = {
-    id: PropTypes.integer.required,
+    id: PropTypes.integer,
     name: PropTypes.string,
     description: PropTypes.string,
     location: PropTypes.string
@@ -395,7 +395,7 @@ const DummyEvents = () => {
   };
 
   DeleteButton.propTypes = {
-    id: PropTypes.integer.required,
+    id: PropTypes.integer,
   }
 
 
@@ -477,7 +477,7 @@ const DummyEvents = () => {
   return (
     <Sidebar>
     <Box mx="156px" pt="30px" justifyContent="flex-start">
-      <Box height="45vh" display="flex" flexDirection="row" gap="83px" justifyContent="center" alignItems={"left"}>
+      <Box height="45vh" display="flex" flexDirection="row" gap="83px" justifyContent="flex-start" alignItems={"left"}>
         <RecentEventsCard/>
         <AllData/>
       </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,6 +418,13 @@
   dependencies:
     "@chakra-ui/shared-utils" "2.0.5"
 
+"@chakra-ui/icons@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icons/-/icons-2.1.1.tgz#58ff0f9e703f2f4f89debd600ce4e438f43f9c9a"
+  integrity sha512-3p30hdo4LlRZTT5CwoAJq3G9fHI0wDc0pBaMHj4SUn0yomO+RcDRlzhdXqdr5cVnzax44sqXJVnf3oQG0eI+4g==
+  dependencies:
+    "@chakra-ui/icon" "3.2.0"
+
 "@chakra-ui/image@2.1.0":
   version "2.1.0"
   resolved "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz"
@@ -4257,6 +4264,11 @@ react-hook-form@7.37.0:
   version "7.37.0"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.37.0.tgz#4d1738f092d3d8a3ade34ee892d97350b1032b19"
   integrity sha512-6NFTxsnw+EXSpNNvLr5nFMjPdYKRryQcelTHg7zwBB6vAzfPIcZq4AExP4heVlwdzntepQgwiOQW4z7Mr99Lsg==
+
+react-icons@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.0.1.tgz#1694e11bfa2a2888cab47dcc30154ce90485feee"
+  integrity sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Authors: @phillipcutter @eachen1010 

### What does this PR contain?

1. Updated DummyEvents page to match lo-fi design and flow from Figma designs
   - Sidebar with clickable buttons to go home or view profile (doesn't do anything currently)
   - Create event button opens previous modal to create an event (some fields are set to defaults for testing, like date/time)
   - Select allows selecting events, with a new delete button that appears
      - Selecting an event and clicking "Delete" brings up a confirmation modal
      - Selecting no events and clicking "Delete" exits selection mode
      - A new "Deselect all" button replaces "Create event" and, when clicked, deselects all events and exits selection mode
   - Clicking any event opens a modal with more information

### How did you test these changes?

We ran the backend locally and tested creating and deleting events to ensure it was working properly (the issue I mentioned during today's dev meeting was caused by me not pulling the latest backend changes lol). We also tested various edge cases, such as clicking delete with no events selected.

### Attach images (if applicable)

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/20cb48bc-fd3c-48cb-ae08-8248486fe530)
`/events` page

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/2966ffd4-7728-4423-9638-9fef15497a19)
Create new event modal (UI of form is still a placeholder)

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/41403d39-beee-426a-a452-37a3519fd0be)
Detailed event modal (triggered when clicking on an event)

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/7cf268fe-0759-41d2-981f-a687d7130cfa)
Selecting events

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/0d8aa8ed-6293-4c5f-9a15-98741675aa9b)
Permanently delete confirmation modal

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/c903c385-c374-41c2-88e2-0c8894bcde90)
Deleted toast

Closes #40 