### PR TITLE
feat: add register guest modal with form validation

### DIFF
--- a/src/components/RegisterGuestModal/RegisterGuestModal.jsx
+++ b/src/components/RegisterGuestModal/RegisterGuestModal.jsx
@@ -1,0 +1,169 @@
+import Backend from '../../utils/utils';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup'; // Corrected import
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+  FormControl,
+  Input,
+  Center,
+  Checkbox,
+  Grid,
+  GridItem,
+  Link,
+  useDisclosure,
+  Text,
+} from '@chakra-ui/react';
+
+const RegisterGuestModal = ({ isOpen, onClose }) => {
+  const volunteerObject = yup.object().shape({
+    first_name: yup.string().required('First name is required'),
+    last_name: yup.string().required('Last name is required'),
+    email: yup.string().email('Invalid email format').required('Email is required'),
+    wavier: yup
+      .boolean()
+      .oneOf([true], 'You must accept the terms and conditions')
+      .required('Waiver is required'),
+  });
+
+  const [volunteerData] = useState({
+    first_name: '',
+    last_name: '',
+    email: '',
+    wavier: false,
+  });
+
+  const {
+    isOpen: isAgreementOpen,
+    onOpen: onAgreementOpen,
+    onClose: onAgreementClose,
+  } = useDisclosure();
+
+  const { register, handleSubmit } = useForm({ defaultValues: volunteerData });
+
+  const postVolunteerData = async formData => {
+    try {
+      const volunteer = {
+        first_name: formData.first_name,
+        last_name: formData.last_name,
+        email: formData.email,
+      };
+      await Backend.post('/profiles/guest', volunteer);
+      onClose();
+    } catch (error) {
+      console.error('Error registering new volunteer:', error.message);
+    }
+  };
+
+  const noReload = (data, event) => {
+    event.preventDefault();
+    volunteerObject
+      .validate(data)
+      .then(function (value) {
+        console.log(value);
+        postVolunteerData(value);
+      })
+      .catch(function (err) {
+        alert(err);
+      });
+  };
+
+  console.log(volunteerData);
+  return (
+    <>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader alignSelf={'center'}>
+            <Text fontWeight={'bold'}>Register New Volunteer</Text>
+          </ModalHeader>
+          {/* postVolunteerData(10, 5, 5, 5, 10, 10) */}
+          <form onSubmit={handleSubmit(noReload)}>
+            <FormControl>
+              <ModalCloseButton />
+              <ModalBody>
+                <FormControl mt={10}>
+                  <Grid
+                    templateColumns="repeat(2, 1fr)" // two columns of equal width
+                    templateRows="repeat(2, 1fr)" // two rows (adjust if you have more rows)
+                    gap={6} // spacing between grid items
+                  >
+                    <GridItem colSpan={1}>
+                      <Text fontWeight={'bold'}>First Name</Text>
+                      <Input
+                        marginTop={5}
+                        placeholder="Johnny"
+                        alignItems={'center'}
+                        {...register('first_name')}
+                        type="string"
+                      />
+                    </GridItem>
+                    <GridItem colSpan={1}>
+                      <Text fontWeight={'bold'}>Last Name</Text>
+                      <Input
+                        marginTop={5}
+                        placeholder="Appleseed"
+                        alignItems={'center'}
+                        {...register('last_name')}
+                        type="string"
+                      />
+                    </GridItem>
+                    <GridItem colSpan={1}>
+                      <Text fontWeight={'bold'}>Email</Text>
+                      <Input
+                        marginTop={5}
+                        placeholder="johnny@gmail.com"
+                        alignItems={'center'}
+                        {...register('email')}
+                        type="string"
+                      />
+                    </GridItem>
+                    <GridItem colSpan={1}>
+                      <Text fontWeight={'bold'}>Wavier</Text>
+                      <Checkbox {...register('wavier')}>
+                        I agree to the{' '}
+                        <Link color="teal.500" onClick={onAgreementOpen}>
+                          terms and conditions
+                        </Link>
+                      </Checkbox>
+                    </GridItem>
+                  </Grid>
+                </FormControl>
+              </ModalBody>
+
+              <Center p={8}>
+                <Button type="submit" color="black" bg="#95D497" w="70%">
+                  Add Volunteer
+                </Button>
+              </Center>
+            </FormControl>
+          </form>
+        </ModalContent>
+      </Modal>
+
+      {/* Modal for Agreement */}
+      <Modal isOpen={isAgreementOpen} onClose={onAgreementClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Terms and Conditions</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>bruh</ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+RegisterGuestModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default RegisterGuestModal;

--- a/src/pages/DummyCheckin.jsx
+++ b/src/pages/DummyCheckin.jsx
@@ -195,7 +195,6 @@ const DummyCheckin = () => {
           <Button
             style={{
               borderRadius: '60px',
-              backgroundColor: `${showCheckedIn ? '#696969' : '#EFEFEF'}`,
             }}
             marginLeft="1vw"
             marginTop="3vh"

--- a/src/pages/DummyCheckin.jsx
+++ b/src/pages/DummyCheckin.jsx
@@ -5,8 +5,19 @@ import Backend from '../utils/utils';
 import Fuse from 'fuse.js';
 import VolunteerEventsTable from '../components/DummyCheckin/VolunteerEventsTable';
 import { useParams } from 'react-router-dom';
-import { Container, Flex, Button, Box, IconButton, FormControl, Input } from '@chakra-ui/react';
+import {
+  Container,
+  Flex,
+  Button,
+  Box,
+  IconButton,
+  FormControl,
+  Input,
+  useDisclosure,
+  Spacer,
+} from '@chakra-ui/react';
 import { SearchIcon } from '@chakra-ui/icons';
+import RegisterGuestModal from '../components/RegisterGuestModal/RegisterGuestModal';
 
 const DummyCheckin = () => {
   const [joinedData, setJoinedData] = useState([]);
@@ -16,7 +27,10 @@ const DummyCheckin = () => {
   const [notCheckedInVolunteers, setNotCheckedInVolunteers] = useState([]);
   const [input, setInput] = useState('');
   const [showCheckedIn, setShowCheckedIn] = useState(false);
+
   const { eventId } = useParams();
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   /*
     Filters on change to joinedData which it relies on, only really necessary once but needs to happen aftr joinedData complete
@@ -154,28 +168,43 @@ const DummyCheckin = () => {
           </FormControl>
         </Container>
 
-        <Button
-          style={{
-            borderRadius: '60px',
-            backgroundColor: `${showCheckedIn ? '#EFEFEF' : '#696969'}`,
-          }}
-          marginLeft="1vw"
-          marginTop="3vh"
-          onClick={() => setShowCheckedIn(false)}
-        >
-          not checked-in
-        </Button>
-        <Button
-          style={{
-            borderRadius: '60px',
-            backgroundColor: `${showCheckedIn ? '#696969' : '#EFEFEF'}`,
-          }}
-          marginLeft="1vw"
-          marginTop="3vh"
-          onClick={() => setShowCheckedIn(true)}
-        >
-          checked-in
-        </Button>
+        <Flex>
+          <Button
+            style={{
+              borderRadius: '60px',
+              backgroundColor: `${showCheckedIn ? '#EFEFEF' : '#696969'}`,
+            }}
+            marginLeft="1vw"
+            marginTop="3vh"
+            onClick={() => setShowCheckedIn(false)}
+          >
+            not checked-in
+          </Button>
+          <Button
+            style={{
+              borderRadius: '60px',
+              backgroundColor: `${showCheckedIn ? '#696969' : '#EFEFEF'}`,
+            }}
+            marginLeft="1vw"
+            marginTop="3vh"
+            onClick={() => setShowCheckedIn(true)}
+          >
+            checked-in
+          </Button>
+          <Spacer />
+          <Button
+            style={{
+              borderRadius: '60px',
+              backgroundColor: `${showCheckedIn ? '#696969' : '#EFEFEF'}`,
+            }}
+            marginLeft="1vw"
+            marginTop="3vh"
+            onClick={onOpen}
+          >
+            + register new volunteer
+          </Button>
+        </Flex>
+        <RegisterGuestModal isOpen={isOpen} onClose={onClose} />
 
         {showCheckedIn &&
           (checkedInVolunteers.length != 0 ? (

--- a/src/pages/DummyCheckin.jsx
+++ b/src/pages/DummyCheckin.jsx
@@ -204,7 +204,7 @@ const DummyCheckin = () => {
             + register new volunteer
           </Button>
         </Flex>
-        <RegisterGuestModal isOpen={isOpen} onClose={onClose} />
+        <RegisterGuestModal isOpen={isOpen} onClose={onClose} eventId={eventId} />
 
         {showCheckedIn &&
           (checkedInVolunteers.length != 0 ? (


### PR DESCRIPTION
@KatyH820 @bobbyzhong 
 close #74
- [x] The RegisterGuest modal matches the design
- [x] The RegisterGuest modal has the specified form input validation using Yup with alert messages
- [x] Backend routes have been updated as needed to facilitate the implementation of the task
- [x] Able to create new users with RegisterGuest modal to route /profiles/guest


<img width="1512" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/96160110/89c0bc48-c1cf-4644-841f-8e06faa636c2">

<img width="1512" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/96160110/cbe5f4ec-6c52-4edc-868b-7e9f15d2e243">

<img width="1512" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/96160110/8aa7d8c2-4cf4-4446-adf1-b2915a8402d0">



