### PR TITLE
86-leaderboard-for-specific-event

### DIFF
--- a/src/components/Leaderboard/Leaderboard.jsx
+++ b/src/components/Leaderboard/Leaderboard.jsx
@@ -1,52 +1,131 @@
-import { Box, Card, Text } from '@chakra-ui/react';
+import { Box, Card, Text, Select } from '@chakra-ui/react';
 import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import Backend from '../../utils/utils.js';
 
 const LeaderboardCard = () => {
-    const [topThree, setTopThree] = useState([]);
+  const [topThree, setTopThree] = useState([]);
+  const [events, setEvents] = useState([]);
+  const [topThreeSpecificEvent, setEventSelect] = useState([]);
+  const [selectedEvent, setSelectedEvent] = useState(-1);
 
-    const getTopThree = async () => {
-        try {
-          const topThreeData = await Backend.get('/stats/leaderboard');
-          console.log(topThreeData);
-          setTopThree(topThreeData.data);
-        } catch (err) {
-          console.log(`Error getting top three volunteers: `, err.message);
-        }
-    };
+  const getEvents = async () => {
+    try {
+      const events = await Backend.get('/events');
+      setEvents(events.data);
+    } catch (err) {
+      console.log(`Error getting top three volunteers: `, err.message);
+    }
+  };
 
-    const truncate = (num, decimalPlaces) => {
-        const factor = Math.pow(10, decimalPlaces);
-        return Math.floor(num * factor) / factor;
-    };    
+  const getTopThree = async () => {
+    try {
+      const topThreeData = await Backend.get('/stats/leaderboard');
+      setTopThree(topThreeData.data);
+    } catch (err) {
+      console.log(`Error getting top three volunteers: `, err.message);
+    }
+  };
 
-    useEffect(() => {
-        getTopThree();
-    }, []);
+  const truncate = (num, decimalPlaces) => {
+    const factor = Math.pow(10, decimalPlaces);
+    return Math.floor(num * factor) / factor;
+  };
+
+  const handleChange = event => {
+    setSelectedEvent(event.target.value);
+    console.log(selectedEvent);
+  };
+
+  const SelectEvent = () => {
+    return (
+      <>
+        <Select placeholder="Select Event" onChange={e => handleChange(e)}>
+          {events.map(event => (
+            <option key={event.id} value={event.id}>
+              {event.name}
+            </option>
+          ))}
+        </Select>
+      </>
+    );
+  };
+
+  const getTopThreeSpecificEvent = async eventID => {
+    try {
+      const topThreeSpecificEvent = await Backend.get(`/stats/leaderboard/${eventID}`);
+      setEventSelect(topThreeSpecificEvent.data);
+    } catch (err) {
+      console.log(`Error getting top three volunteers: `, err.message);
+    }
+  };
+
+  const ActualLeaderboard = ({ LeaderboardArray }) => {
+    return (
+      <>
+        <Box
+          width="331px"
+          height="195px"
+          mx="13px"
+          my="19px"
+          display="flex"
+          flexDir="column"
+          alignContent="center"
+          justifyContent="center"
+          gap="9px"
+          h="100%"
+        >
+          <Text fontWeight="bold" decoration="underline" textAlign="center">
+            top 3 volunteers
+          </Text>
+          <Box mx="23px" bgColor="#2D558A" color="white" borderRadius="60px" padding="2px">
+            <Text fontWeight="bold" color="white" textAlign="center">
+              {LeaderboardArray[0] && LeaderboardArray[0].volunteer_first_name}{' '}
+              {LeaderboardArray[0] && LeaderboardArray[0].volunteer_last_name} ...........{' '}
+              {LeaderboardArray[0] && truncate(LeaderboardArray[0].total_weight, 2)} lbs
+            </Text>
+          </Box>
+          <Text fontWeight="bold" textAlign="center">
+            {LeaderboardArray[1] && LeaderboardArray[1].volunteer_first_name}{' '}
+            {LeaderboardArray[1] && LeaderboardArray[1].volunteer_last_name} ............{' '}
+            {LeaderboardArray[1] && truncate(LeaderboardArray[1].total_weight, 2)} lbs
+          </Text>
+          <Text fontWeight="bold" textAlign="center">
+            {LeaderboardArray[2] && LeaderboardArray[2].volunteer_first_name}{' '}
+            {LeaderboardArray[2] && LeaderboardArray[2].volunteer_last_name} ...........{' '}
+            {LeaderboardArray[2] && truncate(LeaderboardArray[2].total_weight, 2)} lbs
+          </Text>
+        </Box>
+      </>
+    );
+  };
+
+  ActualLeaderboard.propTypes = {
+    LeaderboardArray: PropTypes.array.isRequired,
+  };
+
+  useEffect(() => {
+    getEvents();
+  }, []);
+
+  useEffect(() => {
+    getTopThree();
+  }, []);
+
+  useEffect(() => {
+    getTopThreeSpecificEvent(selectedEvent);
+  }, [selectedEvent]);
 
   return (
-    <> 
-        <Card borderRadius='0px 15px 15px 0px'>
-            <Box
-                width='331px'
-                height='195px'
-                mx="13px"
-                my="19px"
-                display="flex"
-                flexDir="column"
-                alignContent="center"
-                justifyContent="center"
-                gap="9px"
-                h="100%"
-            >
-                <Text fontWeight='bold' decoration='underline' textAlign='center'>top 3 volunteers</Text>
-                <Box mx='23px' bgColor='#2D558A' color='white' borderRadius='60px' padding='2px'>
-                    <Text fontWeight='bold' color='white' textAlign='center'>{topThree[0] && topThree[0].volunteer_first_name} {topThree[0] && topThree[0].volunteer_last_name} ........... {topThree[0] && truncate(topThree[0].total_weight, 2)} lbs</Text>
-                </Box>
-                <Text fontWeight='bold' textAlign='center'>{topThree[1] && topThree[1].volunteer_first_name} {topThree[1] && topThree[1].volunteer_last_name} ............ {topThree[1] && truncate(topThree[1].total_weight, 2)} lbs</Text>
-                <Text fontWeight='bold' textAlign='center'>{topThree[2] && topThree[2].volunteer_first_name} {topThree[2] && topThree[2].volunteer_last_name} ........... {topThree[2] && truncate(topThree[2].total_weight, 2)} lbs</Text>
-            </Box>
-        </Card>
+    <>
+      <Card borderRadius="0px 15px 15px 0px">
+        <SelectEvent />
+        {selectedEvent === -1 ? (
+          <ActualLeaderboard LeaderboardArray={topThree} />
+        ) : (
+          <ActualLeaderboard LeaderboardArray={topThreeSpecificEvent} />
+        )}
+      </Card>
     </>
   );
 };

--- a/src/components/Leaderboard/Leaderboard.jsx
+++ b/src/components/Leaderboard/Leaderboard.jsx
@@ -1,27 +1,20 @@
-import { Box, Card, Text, Select } from '@chakra-ui/react';
+import { Box, Card, Text } from '@chakra-ui/react';
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Backend from '../../utils/utils.js';
 
-const LeaderboardCard = () => {
+const LeaderboardCard = ({ event_id }) => {
   const [topThree, setTopThree] = useState([]);
-  const [events, setEvents] = useState([]);
-  const [topThreeSpecificEvent, setEventSelect] = useState([]);
-  const [selectedEvent, setSelectedEvent] = useState(-1);
-
-  const getEvents = async () => {
-    try {
-      const events = await Backend.get('/events');
-      setEvents(events.data);
-    } catch (err) {
-      console.log(`Error getting top three volunteers: `, err.message);
-    }
-  };
 
   const getTopThree = async () => {
     try {
-      const topThreeData = await Backend.get('/stats/leaderboard');
-      setTopThree(topThreeData.data);
+      if (event_id === -1) {
+        const topThreeData = await Backend.get('/stats/leaderboard');
+        setTopThree(topThreeData.data);
+      } else {
+        const topThreeData = await Backend.get(`/stats/leaderboard/${event_id}`);
+        setTopThree(topThreeData.data);
+      }
     } catch (err) {
       console.log(`Error getting top three volunteers: `, err.message);
     }
@@ -30,34 +23,6 @@ const LeaderboardCard = () => {
   const truncate = (num, decimalPlaces) => {
     const factor = Math.pow(10, decimalPlaces);
     return Math.floor(num * factor) / factor;
-  };
-
-  const handleChange = event => {
-    setSelectedEvent(event.target.value);
-    console.log(selectedEvent);
-  };
-
-  const SelectEvent = () => {
-    return (
-      <>
-        <Select placeholder="Select Event" onChange={e => handleChange(e)}>
-          {events.map(event => (
-            <option key={event.id} value={event.id}>
-              {event.name}
-            </option>
-          ))}
-        </Select>
-      </>
-    );
-  };
-
-  const getTopThreeSpecificEvent = async eventID => {
-    try {
-      const topThreeSpecificEvent = await Backend.get(`/stats/leaderboard/${eventID}`);
-      setEventSelect(topThreeSpecificEvent.data);
-    } catch (err) {
-      console.log(`Error getting top three volunteers: `, err.message);
-    }
   };
 
   const ActualLeaderboard = ({ LeaderboardArray }) => {
@@ -105,29 +70,20 @@ const LeaderboardCard = () => {
   };
 
   useEffect(() => {
-    getEvents();
-  }, []);
-
-  useEffect(() => {
     getTopThree();
   }, []);
-
-  useEffect(() => {
-    getTopThreeSpecificEvent(selectedEvent);
-  }, [selectedEvent]);
 
   return (
     <>
       <Card borderRadius="0px 15px 15px 0px">
-        <SelectEvent />
-        {selectedEvent === -1 ? (
-          <ActualLeaderboard LeaderboardArray={topThree} />
-        ) : (
-          <ActualLeaderboard LeaderboardArray={topThreeSpecificEvent} />
-        )}
+        <ActualLeaderboard LeaderboardArray={topThree} />
       </Card>
     </>
   );
+};
+
+LeaderboardCard.propTypes = {
+  event_id: PropTypes.number.isRequired,
 };
 
 export default LeaderboardCard;

--- a/src/components/Playground/Playground.jsx
+++ b/src/components/Playground/Playground.jsx
@@ -38,7 +38,7 @@ const Playground = () => {
 
       <AddEventsModal />
       <Dropzone />
-      <Leaderboard />
+      <Leaderboard event_id={35} />
     </Flex>
   );
 };


### PR DESCRIPTION
Authors: @gayathriy22 @eachen1010 

What does this PR contain?

- implemented specific event's leaderboards in /playground
- defualt selected shows leaderboard across all s2t events
- when selecting a specific event in dropdown, called appropriate api endpoint and display in frontend

How did you test these changes?
- tested if it updates for all events
