### PR TITLE
fix: modal styling + optional email

### DIFF
--- a/src/components/RegisterGuestModal/RegisterGuestModal.jsx
+++ b/src/components/RegisterGuestModal/RegisterGuestModal.jsx
@@ -21,7 +21,10 @@ import {
   Link,
   useDisclosure,
   Text,
+  InputGroup,
+  InputLeftElement,
 } from '@chakra-ui/react';
+import { IoMdPeople } from 'react-icons/io';
 
 const RegisterGuestModal = ({ isOpen, onClose, eventId }) => {
   const [waiverText, setWaiverText] = useState('');
@@ -37,7 +40,7 @@ const RegisterGuestModal = ({ isOpen, onClose, eventId }) => {
   const volunteerObject = yup.object().shape({
     first_name: yup.string().required('First name is required'),
     last_name: yup.string().required('Last name is required'),
-    email: yup.string().email('Invalid email format').nullable(),
+    email: yup.string().email('Invalid email format').nullable().notRequired(),
     waiver: yup
       .boolean()
       .oneOf([true], 'You must accept the terms and conditions')
@@ -67,12 +70,11 @@ const RegisterGuestModal = ({ isOpen, onClose, eventId }) => {
     formState: { errors },
   } = useForm({ defaultValues: volunteerData, resolver: yupResolver(volunteerObject) });
 
-  const isFormFilled = () => {
+  const isFormIncomplete = () => {
     return (
-      volunteerData.first_name == '' ||
-      volunteerData.last_name == '' ||
-      volunteerData.waiver == false ||
-      volunteerData.email === null // Considering email can be null
+      volunteerData.first_name === '' ||
+      volunteerData.last_name === '' ||
+      volunteerData.waiver === false
     );
   };
 
@@ -190,19 +192,24 @@ const RegisterGuestModal = ({ isOpen, onClose, eventId }) => {
                       <Text fontWeight={'medium'} fontSize={'14px'} color={'#717171'}>
                         Party size
                       </Text>
-                      <Input
-                        marginTop={1}
-                        placeholder="1"
-                        alignItems={'center'}
-                        {...register('party_number')}
-                        type="string"
-                        onChange={e =>
-                          setVolunteerData(prevState => ({
-                            ...prevState,
-                            party_number: e.target.value,
-                          }))
-                        }
-                      />
+                      <InputGroup>
+                        <InputLeftElement paddingTop="0.5em">
+                          <IoMdPeople size={'1.7em'} color="gray" />
+                        </InputLeftElement>
+                        <Input
+                          marginTop={1}
+                          placeholder="1"
+                          alignItems={'center'}
+                          {...register('party_number')}
+                          type="string"
+                          onChange={e =>
+                            setVolunteerData(prevState => ({
+                              ...prevState,
+                              party_number: e.target.value,
+                            }))
+                          }
+                        />
+                      </InputGroup>
                     </GridItem>
                     <GridItem colSpan={1}>
                       <Text fontWeight={'medium'} fontSize={'14px'} color={'#717171'}>
@@ -337,7 +344,7 @@ const RegisterGuestModal = ({ isOpen, onClose, eventId }) => {
                   h="50px"
                   style={{ borderRadius: '12px' }}
                   _hover={{ bg: '#002B99' }}
-                  isDisabled={isFormFilled()}
+                  isDisabled={isFormIncomplete()}
                 >
                   Add Volunteer
                 </Button>

--- a/src/components/RegisterGuestModal/RegisterGuestModal.jsx
+++ b/src/components/RegisterGuestModal/RegisterGuestModal.jsx
@@ -18,7 +18,6 @@ import {
   Checkbox,
   Grid,
   GridItem,
-  Link,
   useDisclosure,
   Text,
   InputGroup,
@@ -60,7 +59,7 @@ const RegisterGuestModal = ({ isOpen, onClose, eventId }) => {
 
   const {
     isOpen: isAgreementOpen,
-    onOpen: onAgreementOpen,
+    // onOpen: onAgreementOpen,
     onClose: onAgreementClose,
   } = useDisclosure();
 
@@ -314,10 +313,7 @@ const RegisterGuestModal = ({ isOpen, onClose, eventId }) => {
                           }))
                         }
                       >
-                        I agree to the{' '}
-                        <Link color="#003FE3" onClick={onAgreementOpen}>
-                          terms and conditions
-                        </Link>
+                        I agree to the terms and conditions
                       </Checkbox>
                       {errors.waiver && <Text color="red">{errors.waiver.message}</Text>}
                     </GridItem>


### PR DESCRIPTION
- [x] Change the modal to be submittable even if the email field is blank
- [x] Remove the terms and conditions hyperlink
- [x] When a guest registers, their status of is_checked_in should default to true instead of false
- [x] Add the missing person icon under the "Party size" input field

close #166 

