### PR TITLE
Fix: Miscellaneous CSS Bug Fixes

### DIFF
--- a/src/components/Auth/AuthPage.jsx
+++ b/src/components/Auth/AuthPage.jsx
@@ -1,0 +1,66 @@
+import { Box, SimpleGrid, Image, Heading } from '@chakra-ui/react';
+import S2T_Logo from '../../Assets/S2T_Logo.png';
+import PropTypes from 'prop-types';
+
+const AuthPage = ({ children }) => {
+  return (
+    <SimpleGrid columns={2} spacing={0} minH={'100vh'} style={{ fontFamily: 'Poppins' }}>
+      <Box
+        backgroundColor="#2D558A"
+        position="relative"
+        display={'flex'}
+        flexDir={'column'}
+        justifyContent={'center'}
+        alignItems={'center'}
+      >
+        <Image
+          borderRadius="full"
+          src={S2T_Logo}
+          alt="Logo"
+          px={['1rem', '2rem', '4rem']}
+          maxH={'24rem'}
+        />
+        <Box
+          sytle={{ display: 'flex', flexDir: 'column', justifyContent: 'center', gap: 10 }}
+          width={'100%'}
+          objectFit={'cover'}
+          px={['1rem', '2rem', '4rem']}
+        >
+          <Heading
+            style={{
+              color: 'white',
+              // fontSize: '40px',
+              fontWeight: '600',
+              // marginTop: '52px',
+              textAlign: 'center',
+            }}
+            fontSize={['24px', '32px', '40px']}
+          >
+            Stand Up To Trash
+          </Heading>
+          <Heading
+            style={{
+              color: 'white',
+              // fontSize: '32px',
+              fontWeight: '600',
+              // marginTop: '20px',
+              textAlign: 'center',
+            }}
+            fontSize={['16px', '24px', '32px']}
+          >
+            Making a Difference
+          </Heading>
+        </Box>
+      </Box>
+      <Box display={'flex'} h="100%" justifyContent={'center'} alignContent={'center'} mx={4}>
+        {children}
+      </Box>
+    </SimpleGrid>
+  );
+};
+
+AuthPage.propTypes = {
+  children: PropTypes.node,
+};
+
+export default AuthPage;

--- a/src/components/Checkin/VolunteerEventsTable.jsx
+++ b/src/components/Checkin/VolunteerEventsTable.jsx
@@ -92,7 +92,11 @@ const RenderVolunteerRow = ({ volunteer, changeIsCheckedIn, isCheckinPage, isVie
           </Flex>
         </Flex>
       </Td>
-      <Td display={{ base: 'none', xl: 'block' }}>{number_in_party}</Td>
+      <Td>
+        <Flex alignItems={'start'} justifyContent={'start'}>
+          <Text fontSize="md">{number_in_party}</Text>
+        </Flex>
+      </Td>
       <Td>
         <Flex gap={2} justifyContent={'center'} alignItems={'center'}>
           {is_checked_in ? (
@@ -218,7 +222,7 @@ const VolunteerEventsTable = ({
               </Flex>
             </Th>
             <Th display={{ base: 'none', xl: 'block' }}>
-              <Flex gap={2}>
+              <Flex>
                 <Text color="#2D3748" fontWeight="650">
                   Party Size
                 </Text>

--- a/src/components/Events/EventFilteredGrid.jsx
+++ b/src/components/Events/EventFilteredGrid.jsx
@@ -18,7 +18,7 @@ import EventCard from '../../components/Events/EventCard';
 import Backend from '../../utils/utils';
 import Fuse from 'fuse.js';
 
-const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButton }) => {
+const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButton, isOpen }) => {
   const [events, setEvents] = useState([]);
   const [displayEvents, setDisplayEvents] = useState([]);
 
@@ -215,7 +215,7 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
                       borderRadius={12}
                       size="lg"
                       maxW="20%"
-                      minW={{ base: '48%', xl: '200px' }}
+                      minW={{ base: '48%', xl: '10em' }}
                     >
                       {getDateOptions()}
                     </Select>
@@ -226,7 +226,7 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
             </Flex>
           </Box>
           <Box>
-            <Grid templateColumns={{ base: 'repeat(1, 1fr)', xl: 'repeat(4, 1fr)' }} gap={6}>
+            <Grid templateColumns={{ base: 'repeat(1, 1fr)', sm: 'repeat(2, 1fr)', md: 'repeat(2, 1fr)', lg: 'repeat(2, 1fr)', xl: isOpen ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)' }} gap={6}>
               {displayEvents.map(element => (
                 <GridItem
                   key={element.id}
@@ -254,10 +254,13 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
   );
 };
 
+
 EventFilteredGrid.propTypes = {
   setCurrentEventId: PropTypes.func.isRequired,
   setIsOpen: PropTypes.func.isRequired,
   setShowOpenDrawerButton: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
 };
+
 
 export default EventFilteredGrid;

--- a/src/pages/EventPage.jsx
+++ b/src/pages/EventPage.jsx
@@ -276,7 +276,6 @@ const Events = () => {
         height="237px"
         padding="32px"
         flexDirection="column"
-        alignItems="center"
         gap="24px"
         borderRadius={'xl'}
       >

--- a/src/pages/ForgotPasswordV2.jsx
+++ b/src/pages/ForgotPasswordV2.jsx
@@ -1,5 +1,4 @@
 import {
-  AbsoluteCenter,
   Box,
   Button,
   Center,
@@ -7,8 +6,6 @@ import {
   Heading,
   Input,
   Link,
-  SimpleGrid,
-  Image,
   Text,
   useToast,
 } from '@chakra-ui/react';
@@ -19,44 +16,13 @@ import { useState } from 'react';
 import * as yup from 'yup';
 import { sendResetPasswordPrompt } from '../utils/firebaseAuthUtils';
 // import logo from '../Assets/Logo.png'; // Make sure you have this logo or replace it with your own
-import S2T_Logo from '../Assets/S2T_Logo.png';
+import AuthPage from '../components/Auth/AuthPage';
 
 const ForgotPasswordV2 = () => {
   return (
-    <SimpleGrid columns={2} spacing={0} height={'100vh'} style={{ fontFamily: 'Poppins' }}>
-      <Box backgroundColor="#2D558A" position="relative">
-        <AbsoluteCenter>
-          <Image borderRadius="full" width={357} height={430} src={S2T_Logo} alt="Logo" />
-          <Box sytle={{ display: 'flex', flexDir: 'column', justifyContent: 'center' }}>
-            <h1
-              style={{
-                color: 'white',
-                fontSize: '40px',
-                fontWeight: '600',
-                marginTop: '52px',
-                textAlign: 'center',
-              }}
-            >
-              Stand Up To Trash
-            </h1>
-            <h1
-              style={{
-                color: 'white',
-                fontSize: '32px',
-                fontWeight: '600',
-                marginTop: '20px',
-                textAlign: 'center',
-              }}
-            >
-              Making a Difference
-            </h1>
-          </Box>
-        </AbsoluteCenter>
-      </Box>
-      <Box marginTop={40}>
-        <ForgotPasswordForm />
-      </Box>
-    </SimpleGrid>
+    <AuthPage>
+      <ForgotPasswordForm />
+    </AuthPage>
   );
 };
 
@@ -115,14 +81,15 @@ const ForgotPasswordForm = () => {
       </Center>
       <Center>
         <Text marginTop={5} fontSize={18}>
-          No worries, we’ll send you reset instructions.
+          No worries, we{`'`}ll send you reset instructions.
         </Text>
       </Center>
       <form onSubmit={handleSubmit(onSubmit)}>
         <FormControl isInvalid={errors.email}>
           <Center>
             <Input
-              width={'40%'}
+              width={'100%'}
+              maxW={'30rem'}
               marginTop={30}
               borderRadius={8}
               placeholder="Email"
@@ -145,7 +112,8 @@ const ForgotPasswordForm = () => {
             textColor={'white'}
             size={'lg'}
             borderRadius={'10'}
-            width={'22%'}
+            width={'100%'}
+            maxW={'16rem'}
           >
             Reset Password
           </Button>

--- a/src/pages/LoginV2.jsx
+++ b/src/pages/LoginV2.jsx
@@ -6,18 +6,15 @@ import {
   FormErrorMessage,
   Heading,
   Input,
-  SimpleGrid,
   Text,
   useToast,
   Image,
   VStack,
-  AbsoluteCenter,
 } from '@chakra-ui/react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import * as yup from 'yup';
-import S2T_Logo from '../Assets/S2T_Logo.png';
 import ggicon from '../Assets/google.png';
 import fbicon from '../Assets/fb.png';
 import { logInWithEmailAndPassWord } from '../utils/firebaseAuthUtils';
@@ -27,6 +24,7 @@ import { useEffect, useContext } from 'react';
 import RoleContext from '../utils/RoleContext';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import { getProfileByFirebaseUid, postProfile } from '../utils/profileUtils';
+import AuthPage from '../components/Auth/AuthPage';
 
 const LoginV2 = () => {
   const auth = getAuth();
@@ -145,46 +143,17 @@ const LoginForm = () => {
   };
 
   return (
-    <SimpleGrid columns={2} spacing={0} height={'100vh'} style={{ fontFamily: 'Poppins' }}>
-      <Box backgroundColor="#2D558A" position="relative">
-        <AbsoluteCenter>
-          <Image borderRadius="full" width={357} height={430} src={S2T_Logo} alt="Logo" />
-          <Box sytle={{ display: 'flex', flexDir: 'column', justifyContent: 'center' }}>
-            <h1
-              style={{
-                color: 'white',
-                fontSize: '40px',
-                fontWeight: '600',
-                marginTop: '52px',
-                textAlign: 'center',
-              }}
-            >
-              Stand Up To Trash
-            </h1>
-            <h1
-              style={{
-                color: 'white',
-                fontSize: '32px',
-                fontWeight: '600',
-                marginTop: '20px',
-                textAlign: 'center',
-              }}
-            >
-              Making a Difference
-            </h1>
-          </Box>
-        </AbsoluteCenter>
-      </Box>
-      <Box marginTop={40}>
+    <AuthPage>
+      <Box style={{ width: '100%' }} height={'fit-content'} mt={'auto'} mb="auto">
         <form onSubmit={handleSubmit(handleLogin)}>
           <Center>
             <Heading marginTop={10}>Log In</Heading>
           </Center>
-          <FormControl isInvalid={errors.email}>
+          <FormControl isInvalid={errors.email} w={'100%'} d="block">
             {/* <FormLabel>Email address</FormLabel> */}
             <Center>
               <Input
-                width={'40%'}
+                maxW={'20rem'}
                 marginTop={30}
                 borderRadius={8}
                 fontFamily={'Avenir'}
@@ -202,7 +171,7 @@ const LoginForm = () => {
             {/* <FormLabel>Password</FormLabel> */}
             <Center>
               <Input
-                width={'40%'}
+                maxW={'20rem'}
                 marginTop={30}
                 borderRadius={8}
                 fontFamily={'Avenir'}
@@ -226,7 +195,8 @@ const LoginForm = () => {
                 textColor={'white'}
                 size={'lg'}
                 borderRadius={'10'}
-                width={'80%'}
+                w={'100%'}
+                maxW={'16rem'}
               >
                 Login
               </Button>
@@ -245,7 +215,8 @@ const LoginForm = () => {
                 leftIcon={<Image src={ggicon} alt="Google Icon" />}
                 size="md"
                 // width={'36.82vh'}
-                width={'115%'}
+                width={'100%'}
+                maxW={'20rem'}
                 marginTop={2}
                 border="1px solid black"
                 backgroundColor={'transparent'}
@@ -257,7 +228,8 @@ const LoginForm = () => {
                 leftIcon={<Image src={fbicon} alt="Facebook Icon" />}
                 size="md"
                 // width={'36.82vh'}
-                width={'115%'}
+                width={'100%'}
+                maxW={'20rem'}
                 marginTop={3}
                 border="1px solid black"
                 backgroundColor={'transparent'}
@@ -284,36 +256,39 @@ const LoginForm = () => {
                     textAlign: 'center',
                     paddingTop: '15px',
                   }}
+                  color={'#478CB6'}
+                  textDecoration={'underline'}
                   onClick={() => navigate('/forgotpasswordv2')}
                 >
                   Forgot Password?
                 </Button>
                 {/* <Text paddingTop='15px'>Forgot Password?</Text> */}
                 <Box display="flex" flexDir="row" paddingTop="20px">
-                  <Text lineHeight="24px">Don’t have an account?</Text>
-
-                  <Button
-                    style={{
-                      background: 'none',
-                      height: '24px',
-                      color: '#478CB6',
-                      fontFamily: 'Avenir',
-                      fontSize: '18px',
-                      fontWeight: '800',
-                      textAlign: 'center',
-                      marginLeft: '-5px',
-                    }}
-                    onClick={() => navigate('/signupv2')}
-                  >
-                    <u>Sign up</u>
-                  </Button>
+                  <Text lineHeight="24px">
+                    Don{`'`}t have an account?{' '}
+                    <Button
+                      style={{
+                        background: 'none',
+                        height: '24px',
+                        color: '#478CB6',
+                        fontFamily: 'Avenir',
+                        fontSize: '18px',
+                        fontWeight: '800',
+                        textAlign: 'center',
+                        marginLeft: '-5px',
+                      }}
+                      onClick={() => navigate('/signupv2')}
+                    >
+                      <u>Sign up</u>
+                    </Button>
+                  </Text>
                 </Box>
               </Box>
             </VStack>
           </Center>
         </form>
       </Box>
-    </SimpleGrid>
+    </AuthPage>
   );
 };
 

--- a/src/pages/SignupV2.jsx
+++ b/src/pages/SignupV2.jsx
@@ -1,17 +1,13 @@
 import {
-  AbsoluteCenter,
-  Box,
   Button,
   Center,
   FormControl,
   FormErrorMessage,
   Heading,
-  HStack,
   Input,
-  Image,
-  SimpleGrid,
   useToast,
   VStack,
+  Stack,
 } from '@chakra-ui/react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
@@ -20,9 +16,9 @@ import * as yup from 'yup';
 import { useContext } from 'react';
 import RoleContext from '../utils/RoleContext';
 // import logo from '../Assets/Logo.png'; // Ensure you have this asset
-import S2T_Logo from '../Assets/S2T_Logo.png';
 import { createUserInFirebase } from '../utils/firebaseAuthUtils';
 import Backend from '../utils/utils';
+import AuthPage from '../components/Auth/AuthPage';
 
 const SignupV2 = () => {
   return (
@@ -120,154 +116,126 @@ const CreateAccount = () => {
   };
 
   return (
-    <SimpleGrid columns={2} spacing={0} height={'100vh'} style={{ fontFamily: 'Poppins' }}>
-      <Box backgroundColor="#2D558A" position="relative">
-        <AbsoluteCenter>
-          <Image borderRadius="full" width={357} height={430} src={S2T_Logo} alt="Logo" />
-          <Box sytle={{ display: 'flex', flexDir: 'column', justifyContent: 'center' }}>
-            <h1
-              style={{
-                color: 'white',
-                fontSize: '40px',
-                fontWeight: '600',
-                marginTop: '52px',
-                textAlign: 'center',
-              }}
+    <AuthPage>
+      <Center>
+        <VStack spacing={4} py={10} px={2}>
+          <Heading>Sign Up</Heading>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Stack
+              spacing={[0, 0, 4]}
+              justifyContent={'center'}
+              direction={['column', 'column', 'row']}
             >
-              Stand Up To Trash
-            </h1>
-            <h1
-              style={{
-                color: 'white',
-                fontSize: '32px',
-                fontWeight: '600',
-                marginTop: '20px',
-                textAlign: 'center',
-              }}
-            >
-              Making a Difference
-            </h1>
-          </Box>
-        </AbsoluteCenter>
-      </Box>
-      <Box marginTop={40}>
-        <Center>
-          <VStack spacing={4} padding={10} width={'48vh'}>
-            <Heading>Sign Up</Heading>
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <HStack spacing={4} justifyContent={'center'}>
-                <FormControl isInvalid={errors.firstName}>
-                  <Input
-                    placeholder="First name"
-                    width={'100%'}
-                    marginTop={30}
-                    marginRight={'70%'}
-                    fontFamily={'Avenir'}
-                    size={'lg'}
-                    borderRadius={8}
-                    boxShadow={'0 4px 2px -2px gray'}
-                    type="text"
-                    {...register('firstName')}
-                  />
-                  {errors.firstName && (
-                    <FormErrorMessage>{errors.firstName?.message}</FormErrorMessage>
-                  )}
-                </FormControl>
-                <FormControl isInvalid={errors.lastName}>
-                  <Input
-                    width={'100%'}
-                    marginTop={30}
-                    size={'lg'}
-                    borderRadius={8}
-                    fontFamily={'Avenir'}
-                    boxShadow={'0 4px 2px -2px gray'}
-                    placeholder="Last name"
-                    type="text"
-                    {...register('lastName')}
-                  />
-                  {errors.lastName && (
-                    <FormErrorMessage>{errors.lastName?.message}</FormErrorMessage>
-                  )}
-                </FormControl>
-              </HStack>
-              <FormControl isInvalid={errors.email}>
-                <Center>
-                  <Input
-                    marginTop={30}
-                    size={'lg'}
-                    borderRadius={8}
-                    fontFamily={'Avenir'}
-                    boxShadow={'0 4px 2px -2px gray'}
-                    placeholder={'Email'}
-                    type="email"
-                    {...register('email')}
-                  />
-                </Center>
-                {errors.email && (
-                  <Center>
-                    <FormErrorMessage>{errors.email?.message}</FormErrorMessage>
-                  </Center>
-                )}
-              </FormControl>
-              <FormControl isInvalid={errors.password}>
-                <Center>
-                  <Input
-                    marginTop={30}
-                    size={'lg'}
-                    borderRadius={8}
-                    fontFamily={'Avenir'}
-                    boxShadow={'0 4px 2px -2px gray'}
-                    placeholder={'Password'}
-                    type="password"
-                    {...register('password')}
-                  />
-                </Center>
-                {errors.password && (
-                  <Center>
-                    <FormErrorMessage>{errors.password?.message}</FormErrorMessage>
-                  </Center>
-                )}
-              </FormControl>
-              <FormControl isInvalid={errors.confirmPassword}>
-                <Center>
-                  <Input
-                    marginTop={30}
-                    size={'lg'}
-                    borderRadius={8}
-                    fontFamily={'Avenir'}
-                    boxShadow={'0 4px 2px -2px gray'}
-                    placeholder={'Confirm Password'}
-                    type="password"
-                    {...register('confirmPassword')}
-                  />
-                </Center>
-                {errors.confirmPassword && (
-                  <Center>
-                    <FormErrorMessage>{errors.confirmPassword?.message}</FormErrorMessage>
-                  </Center>
-                )}
-              </FormControl>
-              <Center>
-                <Button
-                  type="submit"
-                  fontWeight={500}
+              <FormControl isInvalid={errors.firstName}>
+                <Input
+                  placeholder="First name"
+                  width={'100%'}
+                  marginTop={30}
+                  marginRight={'70%'}
+                  fontFamily={'Avenir'}
                   size={'lg'}
-                  borderRadius={10}
-                  marginTop={'5'}
+                  borderRadius={8}
                   boxShadow={'0 4px 2px -2px gray'}
-                  onClick={handleSubmit(onSubmit)}
-                  backgroundColor={'#3182CE'}
-                  textColor={'white'}
-                  width={'20vh'}
-                >
-                  Sign Up Now
-                </Button>
+                  type="text"
+                  {...register('firstName')}
+                />
+                {errors.firstName && (
+                  <FormErrorMessage>{errors.firstName?.message}</FormErrorMessage>
+                )}
+              </FormControl>
+              <FormControl isInvalid={errors.lastName}>
+                <Input
+                  width={'100%'}
+                  marginTop={30}
+                  size={'lg'}
+                  borderRadius={8}
+                  fontFamily={'Avenir'}
+                  boxShadow={'0 4px 2px -2px gray'}
+                  placeholder="Last name"
+                  type="text"
+                  {...register('lastName')}
+                />
+                {errors.lastName && <FormErrorMessage>{errors.lastName?.message}</FormErrorMessage>}
+              </FormControl>
+            </Stack>
+            <FormControl isInvalid={errors.email}>
+              <Center>
+                <Input
+                  marginTop={30}
+                  size={'lg'}
+                  borderRadius={8}
+                  fontFamily={'Avenir'}
+                  boxShadow={'0 4px 2px -2px gray'}
+                  placeholder={'Email'}
+                  type="email"
+                  {...register('email')}
+                />
               </Center>
-            </form>
-          </VStack>
-        </Center>
-      </Box>
-    </SimpleGrid>
+              {errors.email && (
+                <Center>
+                  <FormErrorMessage>{errors.email?.message}</FormErrorMessage>
+                </Center>
+              )}
+            </FormControl>
+            <FormControl isInvalid={errors.password}>
+              <Center>
+                <Input
+                  marginTop={30}
+                  size={'lg'}
+                  borderRadius={8}
+                  fontFamily={'Avenir'}
+                  boxShadow={'0 4px 2px -2px gray'}
+                  placeholder={'Password'}
+                  type="password"
+                  {...register('password')}
+                />
+              </Center>
+              {errors.password && (
+                <Center>
+                  <FormErrorMessage>{errors.password?.message}</FormErrorMessage>
+                </Center>
+              )}
+            </FormControl>
+            <FormControl isInvalid={errors.confirmPassword}>
+              <Center>
+                <Input
+                  marginTop={30}
+                  size={'lg'}
+                  borderRadius={8}
+                  fontFamily={'Avenir'}
+                  boxShadow={'0 4px 2px -2px gray'}
+                  placeholder={'Confirm Password'}
+                  type="password"
+                  {...register('confirmPassword')}
+                />
+              </Center>
+              {errors.confirmPassword && (
+                <Center>
+                  <FormErrorMessage>{errors.confirmPassword?.message}</FormErrorMessage>
+                </Center>
+              )}
+            </FormControl>
+            <Center>
+              <Button
+                type="submit"
+                fontWeight={500}
+                size={'lg'}
+                borderRadius={10}
+                marginTop={'5'}
+                boxShadow={'0 4px 2px -2px gray'}
+                onClick={handleSubmit(onSubmit)}
+                backgroundColor={'#3182CE'}
+                textColor={'white'}
+                width={'100%'}
+                maxW={'16rem'}
+              >
+                Sign Up Now
+              </Button>
+            </Center>
+          </form>
+        </VStack>
+      </Center>
+    </AuthPage>
   );
 };
 

--- a/src/pages/VolunteerEventPage.jsx
+++ b/src/pages/VolunteerEventPage.jsx
@@ -24,7 +24,7 @@ const VolunteerEventPage = () => {
 
   return (
     <Flex dir="column">
-      <Box bg="#E6EAEF" flexGrow={1} minW="1px">
+      <Box bg="#E6EAEF" flexGrow={1} minW="1px" minH={'100vh'}>
         <Flex
           flexDir={'row'}
           alignItems={'center'}

--- a/src/pages/VolunteerEventPage.jsx
+++ b/src/pages/VolunteerEventPage.jsx
@@ -86,6 +86,7 @@ const VolunteerEventPage = () => {
           setCurrentEventId={setCurrentEventId}
           setIsOpen={setIsOpen}
           setShowOpenDrawerButton={setShowOpenDrawerButton}
+          isOpen={isOpen}
         />
       </Box>
       <Box w={isOpen ? '480px' : 0} flexShrink={0}>

--- a/src/pages/Volunteers.jsx
+++ b/src/pages/Volunteers.jsx
@@ -18,6 +18,7 @@ import { GreyCustomSearchIcon } from '../components/Icons/CustomSearchIcon';
 import Fuse from 'fuse.js';
 import { TrophyIcon } from '../components/Icons/TrophyIcon';
 import NavbarContext from '../utils/NavbarContext';
+import { MdPeopleAlt } from 'react-icons/md';
 
 const Volunteers = () => {
   const [registered, setRegistered] = useState('');
@@ -89,11 +90,13 @@ const Volunteers = () => {
               bg="F8F8F8"
               w="100%"
               gap={5}
-              justifyContent="center"
+              pl={"15em"}
+              pr={"15em"}
               mt={5}
+
             >
               {/* Total Registered */}
-              <VStack bg="white" p={30} align="center" w="70%">
+              <Flex bg="white" p={"2em"} align="center" w="35%" h={"14em"} flexDir={"column"} justify={"center"} borderRadius={"12px"}>
                 <Flex background={'#96DB53'} p={2.5} borderRadius={'lg'}>
                   <IoDocumentText size={30} color="white" />
                 </Flex>
@@ -103,12 +106,12 @@ const Volunteers = () => {
                 <Text fontSize={50} fontWeight={'bold'} color={'rgba(0, 0, 0, 0.75)'}>
                   {Math.floor(registered)}
                 </Text>
-              </VStack>
+              </Flex>
 
               {/* Total Checked-In Card */}
-              <VStack bg="white" p={30} align="center" w="70%">
-                <Flex background={'#96DB53'} p={2.5} borderRadius={'lg'}>
-                  <IoDocumentText size={30} color="white" />
+              <VStack bg="white" p={"2em"} align="center" w="35%" h={"14em"} flexDir={"column"} justify={"center"} borderRadius={"12px"}>
+                <Flex background={'#915EFF'} p={2.5} borderRadius={'lg'}>
+                  <MdPeopleAlt size={30} color="white" />
                 </Flex>
                 <Text fontWeight={'medium'} fontSize={20} textAlign={'center'}>
                   Total Checked-In Volunteers
@@ -119,11 +122,11 @@ const Volunteers = () => {
               </VStack>
 
               {/* Leaderboard Card */}
-              <VStack bg="white" p={30} align="center" w="80vw" spacing={5}>
+              <VStack  bg="white" p={"1em"} align="center"  h={"14em"} flexDir={"column"} justify={"center"} borderRadius={"12px"}>
                 <Text fontWeight={'medium'} fontSize={24}>
                   Leaderboard
                 </Text>
-                <Text
+                <Flex
                   textColor="#0075FF"
                   as="b"
                   bg="#D4E4F9"
@@ -132,10 +135,11 @@ const Volunteers = () => {
                   display="flex"
                   justifyContent="space-between"
                   alignItems="center"
-                  w="20vw"
+                  w="11vw"
+                  borderRadius={"4.541px"}
                 >
                   <Flex alignItems="center">
-                    <TrophyIcon marginRight="5" />
+                    <TrophyIcon marginRight="5" boxSize={"1.25em"}/>
                     <Box
                       overflow="hidden"
                       whiteSpace="nowrap"
@@ -148,31 +152,31 @@ const Volunteers = () => {
                   </Flex>
                   {/* <Spacer /> */}
                   <Flex>{topThree[0] && truncate(topThree[0].total_weight, 2)} lbs</Flex>
-                </Text>
-                <Text display="flex" justifyContent="space-between" w="15vw">
-                  <Text color="#0075FF" fontWeight="bold">
-                    2{' '}
-                  </Text>{' '}
-                  <Flex>
+                </Flex>
+                <Flex display="flex" pl={"2em"} gap={"1em"} w="11vw" align={"center"}>
+                  <Text color="#0075FF" fontWeight="bold" fontSize={"1.1em"}>
+                    2
+                  </Text>
+                  <Flex >
                     {topThree[1] && topThree[1].volunteer_first_name}{' '}
                     {topThree[1] && topThree[1].volunteer_last_name}{' '}
                   </Flex>
-                  <Flex>{topThree[1] && truncate(topThree[1].total_weight, 2)} lbs</Flex>
-                </Text>
-                <Text display="flex" justifyContent="space-between" w="15vw">
-                  <Text color="#0075FF" fontWeight="bold">
+                  <Flex >{topThree[1] && truncate(topThree[1].total_weight, 2)} lbs</Flex>
+                </Flex>
+                <Flex display="flex" pl={"2em"} gap={"1em"} w="11vw" align={"center"}>
+                  <Text color="#0075FF" fontWeight="bold" fontSize={"1.1em"}>
                     3{' '}
                   </Text>{' '}
-                  <Flex>
+                  <Flex >
                     {topThree[2] && topThree[2].volunteer_first_name}{' '}
                     {topThree[2] && topThree[2].volunteer_last_name}{' '}
                   </Flex>
-                  <Flex>{topThree[2] && truncate(topThree[2].total_weight, 2)} lbs</Flex>
-                </Text>
+                  <Flex >{topThree[2] && truncate(topThree[2].total_weight, 2)} lbs</Flex>
+                </Flex>
               </VStack>
-              <Box mt="18%" width="60%">
-                <Button colorScheme={'blue'} fontSize="lg">
-                  <ExternalLinkIcon marginRight="2" boxSize="6" /> Export All Volunteer Data
+              <Box mb={"1em"}>
+                <Button backgroundColor={"#0075FF"} fontSize="lg" mt="10.2em">
+                  <ExternalLinkIcon marginRight="2" boxSize="6" color={"white"}/> <Text color={"white"}>Export All Volunteer Data</Text>
                 </Button>
               </Box>
             </Flex>

--- a/src/pages/Volunteers.jsx
+++ b/src/pages/Volunteers.jsx
@@ -86,17 +86,28 @@ const Volunteers = () => {
               onClick={onNavbarDrawerOpen}
             />
             <Flex
-              direction={{ base: 'column', md: 'row' }}
+              direction={{ base: 'column', lg: 'row' }}
               bg="F8F8F8"
               w="100%"
               gap={5}
-              pl={"15em"}
-              pr={"15em"}
+              // pl={"15em"}
+              // pr={"15em"}
+              justifyContent={'center'}
               mt={5}
-
             >
               {/* Total Registered */}
-              <Flex bg="white" p={"2em"} align="center" w="35%" h={"14em"} flexDir={"column"} justify={"center"} borderRadius={"12px"}>
+              <Flex
+                bg="white"
+                p={'2em'}
+                align="center"
+                h={'14em'}
+                maxW={{ base: '100%', lg: '20rem' }}
+                w={'100%'}
+                flexGrow={1}
+                flexDir={'column'}
+                justify={'center'}
+                borderRadius={'12px'}
+              >
                 <Flex background={'#96DB53'} p={2.5} borderRadius={'lg'}>
                   <IoDocumentText size={30} color="white" />
                 </Flex>
@@ -109,7 +120,18 @@ const Volunteers = () => {
               </Flex>
 
               {/* Total Checked-In Card */}
-              <VStack bg="white" p={"2em"} align="center" w="35%" h={"14em"} flexDir={"column"} justify={"center"} borderRadius={"12px"}>
+              <VStack
+                bg="white"
+                p={'2em'}
+                align="center"
+                h={'14em'}
+                flexDir={'column'}
+                justify={'center'}
+                borderRadius={'12px'}
+                maxW={{ base: '100%', lg: '20rem' }}
+                w={'100%'}
+                flexGrow={1}
+              >
                 <Flex background={'#915EFF'} p={2.5} borderRadius={'lg'}>
                   <MdPeopleAlt size={30} color="white" />
                 </Flex>
@@ -122,7 +144,19 @@ const Volunteers = () => {
               </VStack>
 
               {/* Leaderboard Card */}
-              <VStack  bg="white" p={"1em"} align="center"  h={"14em"} flexDir={"column"} justify={"center"} borderRadius={"12px"}>
+              <VStack
+                bg="white"
+                p={'1em'}
+                align="center"
+                h={'14em'}
+                flexDir={'column'}
+                justify={'center'}
+                borderRadius={'12px'}
+                minW={'18rem'}
+                maxW={{ base: '100%', lg: '18rem' }}
+                flexGrow={1}
+                flexBasis={0}
+              >
                 <Text fontWeight={'medium'} fontSize={24}>
                   Leaderboard
                 </Text>
@@ -135,11 +169,11 @@ const Volunteers = () => {
                   display="flex"
                   justifyContent="space-between"
                   alignItems="center"
-                  w="11vw"
-                  borderRadius={"4.541px"}
+                  w="100%"
+                  borderRadius={'4.541px'}
                 >
                   <Flex alignItems="center">
-                    <TrophyIcon marginRight="5" boxSize={"1.25em"}/>
+                    <TrophyIcon marginRight="5" boxSize={'1.25em'} />
                     <Box
                       overflow="hidden"
                       whiteSpace="nowrap"
@@ -153,30 +187,45 @@ const Volunteers = () => {
                   {/* <Spacer /> */}
                   <Flex>{topThree[0] && truncate(topThree[0].total_weight, 2)} lbs</Flex>
                 </Flex>
-                <Flex display="flex" pl={"2em"} gap={"1em"} w="11vw" align={"center"}>
-                  <Text color="#0075FF" fontWeight="bold" fontSize={"1.1em"}>
+                <Flex display="flex" pl={'2em'} gap={'1em'} w="100%" align={'center'}>
+                  <Text color="#0075FF" fontWeight="bold" fontSize={'1.1em'}>
                     2
                   </Text>
-                  <Flex >
+                  <Flex>
                     {topThree[1] && topThree[1].volunteer_first_name}{' '}
                     {topThree[1] && topThree[1].volunteer_last_name}{' '}
                   </Flex>
-                  <Flex >{topThree[1] && truncate(topThree[1].total_weight, 2)} lbs</Flex>
+                  <Flex>{topThree[1] && truncate(topThree[1].total_weight, 2)} lbs</Flex>
                 </Flex>
-                <Flex display="flex" pl={"2em"} gap={"1em"} w="11vw" align={"center"}>
-                  <Text color="#0075FF" fontWeight="bold" fontSize={"1.1em"}>
+                <Flex display="flex" pl={'2em'} gap={'1em'} w="100%" align={'center'}>
+                  <Text color="#0075FF" fontWeight="bold" fontSize={'1.1em'}>
                     3{' '}
                   </Text>{' '}
-                  <Flex >
+                  <Flex>
                     {topThree[2] && topThree[2].volunteer_first_name}{' '}
                     {topThree[2] && topThree[2].volunteer_last_name}{' '}
                   </Flex>
-                  <Flex >{topThree[2] && truncate(topThree[2].total_weight, 2)} lbs</Flex>
+                  <Flex>{topThree[2] && truncate(topThree[2].total_weight, 2)} lbs</Flex>
                 </Flex>
               </VStack>
-              <Box mb={"1em"}>
-                <Button backgroundColor={"#0075FF"} fontSize="lg" mt="10.2em">
-                  <ExternalLinkIcon marginRight="2" boxSize="6" color={"white"}/> <Text color={"white"}>Export All Volunteer Data</Text>
+              <Box
+                display={'flex'}
+                justifyContent={{ base: 'center', lg: 'start' }}
+                alignItems={'end'}
+              >
+                <Button
+                  backgroundColor={'#0075FF'}
+                  fontSize="lg"
+                  style={{
+                    whiteSpace: 'normal',
+                    wordWrap: 'break-word',
+                  }}
+                  height={'fit-content'}
+                >
+                  <ExternalLinkIcon marginRight="2" boxSize="6" color={'white'} />{' '}
+                  <Text color={'white'} my="3">
+                    Export All Volunteer Data
+                  </Text>
                 </Button>
               </Box>
             </Flex>


### PR DESCRIPTION
Authors: @phillipcutter @stevem-zhou 

### What does this PR contain?

Fix several front-end styline issues

### How did you test these changes?

Tested these changes at different aspect ratios and screen sizes to make sure the pages now resize and look correct

### Attach images (if applicable)


#### Auth pages

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/40041ffb-591f-4abe-8942-3953d173570f)
Login page very zoomed in, no squishing over input boxes taking too much space

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/a6adefb3-0f9a-48bd-bd2c-8f3b9e965cfe)
Forgot password page

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/c73672c1-be71-4c98-9d90-795b13846be1)
Sign up page

#### Other pages

<img width="725" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/f2cd33ac-b433-4e00-a538-f81a3af66d9c">
"Party size" table box with correct background styling

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/b5491a1d-30d4-4ce9-b74b-b51dba9b5493)
Volunteer event sidebar no longer squishing main content

![image](https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/c95c5154-135f-4d01-8c92-87f399404da2)
Upcoming events header is no longer squished

<img width="758" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/80cae9d9-6c50-4e27-9df0-0d6ac3af0a61">
<img width="844" alt="image" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/5022578/d999acaa-bb99-44fd-bcdc-ff68e1060fb7">
Volunteers header properly resizing based on screen width

Closes #180