### PR TITLE
style: restyle input dashboard & leaderboard

### DIFF
--- a/src/components/Checkin/VolunteerEventsTable.jsx
+++ b/src/components/Checkin/VolunteerEventsTable.jsx
@@ -56,15 +56,28 @@ const RenderVolunteerRow = ({ volunteer, changeIsCheckedIn, isCheckinPage, isVie
   return (
     <Tr key={id} bg="#FFFFFF" fontWeight={'medium'}>
       <Td>
-        <Flex maxWidth={{ base: '200px', md: '200px', lg: '300px', xl: '300px' }}>
-          <Image src={image_url} boxSize="4rem" borderRadius="full" />
-          <Flex direction="column" ml={3} mt={4} g={1} maxW="75%">
+        <Flex
+          maxWidth={{ base: '200px', md: '200px', lg: '300px', xl: '300px' }}
+          alignItems={'center'}
+          gap={4}
+        >
+          <Image
+            src={image_url}
+            boxSize="4rem"
+            borderRadius="full"
+            maxW={'30%'}
+            h={'fit-content'}
+            aspectRatio={1}
+          />
+
+          <Flex direction="column" g={1} maxW="75%">
             <Text color={'#2D3748'} overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
               {first_name} {last_name}
             </Text>
           </Flex>
         </Flex>
       </Td>
+
       <Td display={{ base: 'none', lg: 'table-cell' }}>
         <Flex>
           <Box backgroundColor="#8589dc" boxSize="2rem" borderRadius="full" mr={5}>
@@ -88,7 +101,9 @@ const RenderVolunteerRow = ({ volunteer, changeIsCheckedIn, isCheckinPage, isVie
             justifyContent={'center'}
           >
             <Image src={status === 'Checked-in' ? checked_in : registered} />
-            <Text fontSize="md">{status}</Text>
+            <Text fontSize="md" textOverflow={'ellipsis'} maxW={48} overflow={'hidden'}>
+              {status}
+            </Text>
           </Flex>
         </Flex>
       </Td>

--- a/src/components/Checkin/VolunteerEventsTable.jsx
+++ b/src/components/Checkin/VolunteerEventsTable.jsx
@@ -236,7 +236,7 @@ const VolunteerEventsTable = ({
                 </Text>
               </Flex>
             </Th>
-            <Th display={{ base: 'none', xl: 'block' }}>
+            <Th>
               <Flex>
                 <Text color="#2D3748" fontWeight="650">
                   Party Size

--- a/src/components/InputData/InputDataDashboard.jsx
+++ b/src/components/InputData/InputDataDashboard.jsx
@@ -105,8 +105,9 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
         </Flex>
 
         <Flex
-          gap={{ base: '3', xl: '10' }}
+          gap={{ base: '3', xl: '5' }}
           w={{ base: '100%', xl: '75%' }}
+          h={{ xl: '100%' }}
           // h={{ base: '10vh', xl: '100%' }}
           marginTop={{ base: '5vh', xl: '0' }}
           justifyContent={'center'}
@@ -117,8 +118,8 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             p={30}
             borderRadius="md"
             align="center"
-            w={{ base: '238px', xl: '70%' }}
-            h={{ base: '211px', xl: '80%' }}
+            w={{ base: '238px', xl: '100%' }}
+            h={{ base: '211px', xl: '100%' }}
             flexDir={'column'}
             gap={3}
             justifyContent={'center'}
@@ -139,12 +140,12 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             </Text>
           </Flex>
           <Flex
-            bg="white"
+            bg="red"
             p={30}
             borderRadius="md"
             align="center"
-            w={{ base: '238px', xl: '70%' }}
-            h={{ base: '211px', xl: '80%' }}
+            w={{ base: '238px', xl: '100%' }}
+            h={{ base: '211px', xl: '100%' }}
             flexDir={'column'}
             gap={3}
             justifyContent={'center'}
@@ -172,7 +173,9 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             </Center>
           </Flex>
 
-          <Leaderboard event_id={event.id} />
+          <Flex h={{ base: '211px', xl: '100%' }} bg="white">
+            <Leaderboard event_id={event.id} />
+          </Flex>
         </Flex>
       </Flex>
     </Flex>

--- a/src/components/InputData/InputDataDashboard.jsx
+++ b/src/components/InputData/InputDataDashboard.jsx
@@ -155,18 +155,14 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             </Flex>
             <Flex>
               <Center>
-                <Text fontWeight={'medium'} fontSize={{ base: '18px', xl: '22px' }}>
+                <Text fontWeight={'medium'} fontSize={18}>
                   Trash Collected
                 </Text>
               </Center>
             </Flex>
 
             <Center>
-              <Text
-                fontSize={{ base: '40px', xl: '50px' }}
-                fontWeight={'bold'}
-                color={'rgba(0, 0, 0, 0.75)'}
-              >
+              <Text fontSize={32} fontWeight={'bold'} color={'rgba(0, 0, 0, 0.75)'}>
                 {trashCollected} lb
               </Text>
             </Center>

--- a/src/components/InputData/InputDataDashboard.jsx
+++ b/src/components/InputData/InputDataDashboard.jsx
@@ -39,41 +39,58 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
 
   return (
     <Flex
-      minW="95%"
       bg={'#F8F8F8'}
       borderRadius="lg"
       alignItems="center"
-      p={10}
-      w={{ base: '0em', xl: '15em' }}
-      h={{ base: '30em', xl: '25em' }}
+      p={18}
+      w={'100%'}
+      justifyContent={'space-between'}
     >
-      <Flex direction={{ base: 'column', xl: 'row' }} w={'full'} alignItems="center" h={'full'}>
+      <Flex
+        direction={{ base: 'column', xl: 'row' }}
+        w={'full'}
+        h={'full'}
+        justifyContent={'space-between'}
+        alignItems="center"
+        gap={7}
+      >
         <Flex flexDir={'column'} w={{ base: '100%', xl: '45%' }}>
           <Box>{event && <HappeningInChip date={new Date(Date.parse(event['date']))} />}</Box>
-          <HStack>
+
+          <HStack justify={'space-between'} gap={4}>
             <Text
               fontSize={{ base: '36px', xl: '30px' }}
               fontWeight="bold"
               color={'rgba(0, 0, 0, 0.75)'}
-              w={{ base: '50%' }}
+              style={{
+                display: '-webkit-box',
+                lineClamp: 1,
+                WebkitLineClamp: 1,
+                WebkitBoxOrient: 'vertical',
+              }}
+              overflow={'hidden'}
+              wordBreak={true}
             >
-              {event?.name}
+              Christmas Beach Cleanup
+              {/* {event?.name} */}
             </Text>
+
             <Button
               leftIcon={<FaPen />}
               onClick={onOpen}
               size="sm"
-              ml="3"
               variant="outline"
               colorScheme="blue"
+              minW={70}
             >
               Edit
             </Button>
+
             <EditEventModal event={event} isOpen={isOpen} onClose={onClose} />
           </HStack>
 
           <Flex mt={3} w="70%" justify={'space-between'}>
-            <Flex flexDir={{ base: 'row', xl: 'column' }} gap={3}>
+            <Flex flexDir={{ base: 'row', xl: 'column' }} gap={2}>
               <Flex alignItems={'center'} gap={2}>
                 <Flex bg={'#7B7C7D'} p={2} borderRadius={'lg'}>
                   <CalendarIcon color={'white'} />
@@ -106,50 +123,50 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
 
         <Flex
           gap={{ base: '3', xl: '5' }}
-          w={{ base: '100%', xl: '75%' }}
           h={{ xl: '100%' }}
-          // h={{ base: '10vh', xl: '100%' }}
-          marginTop={{ base: '5vh', xl: '0' }}
           justifyContent={'center'}
           alignItems={'center'}
+          maxH={200}
         >
           <Flex
             bg="white"
             p={30}
             borderRadius="md"
             align="center"
-            w={{ base: '238px', xl: '100%' }}
-            h={{ base: '211px', xl: '100%' }}
             flexDir={'column'}
             gap={3}
             justifyContent={'center'}
             alignItems={'center'}
+            width={200}
           >
             <Flex background={'#915EFF'} p={2.5} borderRadius={'lg'}>
               <IoMdPeople w={{ base: '42.782px', xl: '42.782px' }} color="white" />
             </Flex>
-            <Text fontWeight={'medium'} fontSize={{ base: '18px', xl: '22px' }}>
-              Checked-In
-            </Text>
-            <Text
-              fontSize={{ base: '40px', xl: '50px' }}
-              fontWeight={'bold'}
-              color={'rgba(0, 0, 0, 0.75)'}
-            >
-              {checkin}
-            </Text>
+            <Flex>
+              <Center>
+                <Text fontWeight={'medium'} fontSize={18}>
+                  Checked-In
+                </Text>
+              </Center>
+            </Flex>
+
+            <Center>
+              <Text fontSize={32} fontWeight={'bold'} color={'rgba(0, 0, 0, 0.75)'}>
+                {checkin}
+              </Text>
+            </Center>
           </Flex>
+
           <Flex
-            bg="red"
+            bg="white"
             p={30}
             borderRadius="md"
             align="center"
-            w={{ base: '238px', xl: '100%' }}
-            h={{ base: '211px', xl: '100%' }}
             flexDir={'column'}
             gap={3}
             justifyContent={'center'}
             alignItems={'center'}
+            width={200}
           >
             <Flex background={'#FF84B0'} p={2.5} borderRadius={'lg'}>
               <FaScaleBalanced w={{ base: '42.782px', xl: '42.782px' }} color="white" />
@@ -169,7 +186,7 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             </Center>
           </Flex>
 
-          <Flex h={{ base: '211px', xl: '100%' }} bg="white">
+          <Flex bg="white">
             <Leaderboard event_id={event.id} />
           </Flex>
         </Flex>

--- a/src/components/InputData/InputDataDashboard.jsx
+++ b/src/components/InputData/InputDataDashboard.jsx
@@ -71,8 +71,7 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
               overflow={'hidden'}
               wordBreak={true}
             >
-              Christmas Beach Cleanup
-              {/* {event?.name} */}
+              {event?.name}
             </Text>
 
             <Button

--- a/src/components/InputData/InputDataDashboard.jsx
+++ b/src/components/InputData/InputDataDashboard.jsx
@@ -121,13 +121,7 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
           </Flex>
         </Flex>
 
-        <Flex
-          gap={{ base: '3', xl: '5' }}
-          h={{ xl: '100%' }}
-          justifyContent={'center'}
-          alignItems={'center'}
-          maxH={200}
-        >
+        <Flex gap={3} justifyContent={'center'} alignItems={'center'} h={200}>
           <Flex
             bg="white"
             p={30}
@@ -138,6 +132,7 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             justifyContent={'center'}
             alignItems={'center'}
             width={200}
+            aspectRatio={1}
           >
             <Flex background={'#915EFF'} p={2.5} borderRadius={'lg'}>
               <IoMdPeople w={{ base: '42.782px', xl: '42.782px' }} color="white" />
@@ -167,6 +162,7 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             justifyContent={'center'}
             alignItems={'center'}
             width={200}
+            aspectRatio={1}
           >
             <Flex background={'#FF84B0'} p={2.5} borderRadius={'lg'}>
               <FaScaleBalanced w={{ base: '42.782px', xl: '42.782px' }} color="white" />
@@ -186,7 +182,7 @@ const InputDataDashboard = ({ event, checkin, trashCollected }) => {
             </Center>
           </Flex>
 
-          <Flex bg="white">
+          <Flex bg="white" borderRadius="md">
             <Leaderboard event_id={event.id} />
           </Flex>
         </Flex>

--- a/src/components/Leaderboard/Leaderboard.jsx
+++ b/src/components/Leaderboard/Leaderboard.jsx
@@ -30,117 +30,121 @@ const LeaderboardCard = ({ event_id }) => {
     return (
       <>
         <Flex
-          mx="5px"
-          // my="19px"
           display="flex"
           flexDir="column"
-          alignContent="center"
           justifyContent="center"
-          gap={{ base: '2px', xl: '5px' }}
-          h={{ base: '211px', xl: '100%' }}
+          width={250}
+          h={200}
+          rounded={8}
+          p={30}
+          overflowY={'scroll'}
         >
-          <Text
-            fontSize={{ base: '22px', xl: '22px' }}
-            fontWeight="sm"
-            textAlign="center"
-            marginTop={{ xl: '0' }}
-          >
+          <Text fontWeight="sm" textAlign="center" fontSize={'large'} pt={30} pb={4}>
             Leaderboard
           </Text>
 
-          {/* 1ST PLACE */}
-          <Flex
-            bgColor="#D4E4F9"
-            color="#1873FB"
-            borderRadius={'md'}
-            px={{ base: 2, xl: 3 }}
-            py={2}
-            alignItems={'center'}
-            gap={3}
-            fontSize={{ base: '16px', xl: '16px' }}
-          >
-            <Flex gap={2} alignItems={'center'} w={'9rem'}>
-              <Flex justifyContent={'center'} w={{ base: '12px', xl: '30px' }}>
-                <Image src={first} />
-              </Flex>
-              <Text
-                fontWeight="bold"
-                fontSize={{ base: '16px', xl: '16px' }}
-                w="auto"
-                textAlign="center"
-              >
-                {LeaderboardArray[0] && LeaderboardArray[0].volunteer_first_name}{' '}
-                {LeaderboardArray[0] && LeaderboardArray[0].volunteer_last_name}
-              </Text>
-            </Flex>
-            <Text fontWeight="bold">
-              {LeaderboardArray[0] && truncate(LeaderboardArray[0].total_weight, 2)} lb
-            </Text>
-          </Flex>
-
-          {/* 2ND PLACE */}
-          <Flex
-            color="black"
-            borderRadius={'md'}
-            px={{ base: 2, xl: 3 }}
-            py={2}
-            alignItems={'center'}
-            gap={3}
-            fontSize={{ base: '16px', xl: '16px' }}
-          >
-            <Flex gap={{ base: '2', xl: '4' }} alignItems={'center'} w={'9rem'}>
-              <Flex justifyContent={'center'} w={{ base: '14px', xl: '30px' }}>
-                <Text color="#1873FB" fontWeight={'medium'} fontSize={{ base: '20px', xl: '3xl' }}>
-                  2
+          <Flex direction={'column'} gap={2}>
+            {/* 1ST PLACE */}
+            <Flex
+              bgColor="#D4E4F9"
+              color="#1873FB"
+              borderRadius={'md'}
+              alignItems={'center'}
+              gap={3}
+              fontSize={{ base: '16px', xl: '16px' }}
+              px={2}
+              py={3}
+              maxW={'100%'}
+            >
+              <Flex gap={2} alignItems={'center'} w={'9rem'}>
+                <Flex justifyContent={'center'} w={6}>
+                  <Image src={first} />
+                </Flex>
+                <Text
+                  fontWeight="bold"
+                  fontSize={{ base: '16px', xl: '16px' }}
+                  w="auto"
+                  overflow={'hidden'}
+                  textOverflow={'ellipsis'}
+                  whiteSpace="nowrap"
+                >
+                  {LeaderboardArray[0] && LeaderboardArray[0].volunteer_first_name}{' '}
+                  {LeaderboardArray[0] && LeaderboardArray[0].volunteer_last_name}
                 </Text>
               </Flex>
-              <Text
-                fontWeight="medium"
-                fontSize={{ base: '16px', xl: '16px' }}
-                textAlign="center"
-                whiteSpace="nowrap"
-                maxWidth={{ base: '100px', xl: '150px' }}
-                overflow="hidden"
-              >
-                {LeaderboardArray[1] && LeaderboardArray[1].volunteer_first_name}{' '}
-                {LeaderboardArray[1] && LeaderboardArray[1].volunteer_last_name}
+              <Text fontWeight="bold" whiteSpace="nowrap">
+                {LeaderboardArray[0] && truncate(LeaderboardArray[0].total_weight, 2)} lb
               </Text>
             </Flex>
-            <Text fontWeight="medium" fontSize={{ base: '14px', xl: '16px' }}>
-              {LeaderboardArray[1] && truncate(LeaderboardArray[1].total_weight, 2)} lb
-            </Text>
-          </Flex>
 
-          {/* 3RD PLACE */}
-          <Flex
-            borderRadius={'md'}
-            px={{ base: 2, xl: 3 }}
-            py={2}
-            alignItems={'center'}
-            gap={{ base: '2', xl: '3' }}
-            fontSize={{ base: '16px', xl: 'lg' }}
-          >
-            <Flex gap={{ base: '2', xl: '4' }} alignItems={'center'} w={'9rem'}>
-              <Flex justifyContent={'center'} w={{ base: '14px', xl: '30px' }}>
-                <Text color="#1873FB" fontWeight={'medium'} fontSize={{ base: '20px', xl: '3xl' }}>
-                  3
+            {/* 2ND PLACE */}
+            <Flex
+              color="black"
+              borderRadius={'md'}
+              alignItems={'center'}
+              gap={3}
+              fontSize={{ base: '16px', xl: '16px' }}
+              px={2}
+              maxW={'100%'}
+            >
+              <Flex gap={{ base: '2', xl: '4' }} alignItems={'center'} w={'9rem'}>
+                <Flex justifyContent={'center'}>
+                  <Text color="#1873FB" fontWeight={'medium'} fontSize={24}>
+                    2
+                  </Text>
+                </Flex>
+
+                <Text
+                  fontWeight="medium"
+                  fontSize={{ base: '16px', xl: '16px' }}
+                  textAlign="center"
+                  whiteSpace="nowrap"
+                  maxWidth={20}
+                  overflow="hidden"
+                  textOverflow={'ellipsis'}
+                >
+                  {LeaderboardArray[1] && LeaderboardArray[1].volunteer_first_name}{' '}
+                  {LeaderboardArray[1] && LeaderboardArray[1].volunteer_last_name}
                 </Text>
               </Flex>
-              <Text
-                fontWeight="semibold"
-                fontSize={{ base: '16px', xl: '16px' }}
-                textAlign="center"
-                whiteSpace="nowrap"
-                maxWidth={{ base: '100px', xl: '150px' }}
-                overflow="hidden"
-              >
-                {LeaderboardArray[2] && LeaderboardArray[2].volunteer_first_name}{' '}
-                {LeaderboardArray[2] && LeaderboardArray[2].volunteer_last_name}
+
+              <Text fontWeight="medium" fontSize={{ base: '14px', xl: '16px' }} whiteSpace="nowrap">
+                {LeaderboardArray[1] && truncate(LeaderboardArray[1].total_weight, 2)} lb
               </Text>
             </Flex>
-            <Text fontWeight="semibold" fontSize={{ base: '14px', xl: 'lg' }}>
-              {LeaderboardArray[2] && truncate(LeaderboardArray[2].total_weight, 2)} lb
-            </Text>
+
+            {/* 3RD PLACE */}
+            <Flex
+              borderRadius={'md'}
+              alignItems={'center'}
+              gap={{ base: '2', xl: '3' }}
+              fontSize={{ base: '16px', xl: 'lg' }}
+              px={2}
+              maxW={'100%'}
+            >
+              <Flex gap={{ base: '2', xl: '4' }} alignItems={'center'} w={'9rem'}>
+                <Flex justifyContent={'center'}>
+                  <Text color="#1873FB" fontWeight={'medium'} fontSize={24}>
+                    3
+                  </Text>
+                </Flex>
+                <Text
+                  fontWeight="medium"
+                  fontSize={{ base: '16px', xl: '16px' }}
+                  textAlign="center"
+                  whiteSpace="nowrap"
+                  overflow="hidden"
+                  textOverflow={'ellipsis'}
+                  maxWidth={20}
+                >
+                  {LeaderboardArray[2] && LeaderboardArray[2].volunteer_first_name}{' '}
+                  {LeaderboardArray[2] && LeaderboardArray[2].volunteer_last_name}
+                </Text>
+              </Flex>
+              <Text fontWeight="medium" fontSize={{ base: '14px', xl: '16px' }} whiteSpace="nowrap">
+                {LeaderboardArray[2] && truncate(LeaderboardArray[2].total_weight, 2)} lb
+              </Text>
+            </Flex>
           </Flex>
         </Flex>
       </>

--- a/src/components/Leaderboard/Leaderboard.jsx
+++ b/src/components/Leaderboard/Leaderboard.jsx
@@ -1,4 +1,4 @@
-import { Card, Text, Flex, Image } from '@chakra-ui/react';
+import { Text, Flex, Image } from '@chakra-ui/react';
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Backend from '../../utils/utils.js';
@@ -31,15 +31,20 @@ const LeaderboardCard = ({ event_id }) => {
       <>
         <Flex
           mx="5px"
-          my="19px"
+          // my="19px"
           display="flex"
           flexDir="column"
           alignContent="center"
           justifyContent="center"
           gap={{ base: '2px', xl: '5px' }}
-          h="80%"
+          h={{ base: '211px', xl: '100%' }}
         >
-          <Text fontSize={{ base: '22px', xl: '22px' }} fontWeight="sm" textAlign="center">
+          <Text
+            fontSize={{ base: '22px', xl: '22px' }}
+            fontWeight="sm"
+            textAlign="center"
+            marginTop={{ xl: '0' }}
+          >
             Leaderboard
           </Text>
 
@@ -153,15 +158,16 @@ const LeaderboardCard = ({ event_id }) => {
 
   return (
     <>
-      <Card
+      {/* <Card
         borderRadius="lg"
         p={3}
         shadow={'none'}
         w={{ base: '288px', xl: '100%' }}
         h={{ base: '212px', xl: '80%' }}
       >
-        <ActualLeaderboard LeaderboardArray={topThree} />
-      </Card>
+        
+      </Card> */}
+      <ActualLeaderboard LeaderboardArray={topThree} />
     </>
   );
 };

--- a/src/pages/InputDataPage.jsx
+++ b/src/pages/InputDataPage.jsx
@@ -169,16 +169,18 @@ const InputDataPage = () => {
         </Flex>
         <CheckinInputPageToggle eventId={eventId} isCheckinPage={false} />
       </Flex>
+
       <InputDataDashboard
         event={event}
         registered={registered}
         checkin={checkin}
         trashCollected={trashCollected}
       />
-      <Container borderRadius={'xl'} mt={10} bg={'#F8F8F8'} minW="95%">
+
+      <Container borderRadius={'xl'} mt={18} bg={'#F8F8F8'} minW="95%">
         {/* SEARCH BAR---- */}
         <Flex gap={3} mt={5} mb={5}>
-          <InputGroup mt={10}>
+          <InputGroup>
             <InputLeftElement pointerEvents="none" top={'6px'} left={'5px'}>
               <GreyCustomSearchIcon w={'24px'} h={'18px'} />
             </InputLeftElement>

--- a/src/pages/InputDataPage.jsx
+++ b/src/pages/InputDataPage.jsx
@@ -147,8 +147,9 @@ const InputDataPage = () => {
       bg="#E6EAEF"
       minH="100vh"
       ml={{ base: '0', xl: '15rem' }}
+      px={5}
     >
-      <Flex minW="95%" justifyContent={'space-between'} mt={10} mb={5}>
+      <Flex width={'100%'} justifyContent={'space-between'} mt={10} mb={5}>
         <Flex alignItems={'center'} gap={3}>
           <HamburgerIcon
             color={'#717171'}
@@ -177,9 +178,9 @@ const InputDataPage = () => {
         trashCollected={trashCollected}
       />
 
-      <Container borderRadius={'xl'} mt={18} bg={'#F8F8F8'} minW="95%">
+      <Container borderRadius={'xl'} my={18} p={18} bg={'#F8F8F8'} minW={'100%'}>
         {/* SEARCH BAR---- */}
-        <Flex gap={3} mt={5} mb={5}>
+        <Flex gap={3} mb={5}>
           <InputGroup>
             <InputLeftElement pointerEvents="none" top={'6px'} left={'5px'}>
               <GreyCustomSearchIcon w={'24px'} h={'18px'} />


### PR DESCRIPTION
Authors: @MatthewCCChang @KevinWu098 

## Summary
1. Restyled the dashboard and leaderboard for responsiveness

<img width="1728" alt="Screenshot 2024-05-11 at 2 17 11 PM" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/100006999/7d3b5fd8-c22d-4470-a11a-c2db9ac0c5b7">
<img width="1728" alt="Screenshot 2024-05-11 at 2 17 20 PM" src="https://github.com/ctc-uci/stand-up-to-trash-frontend/assets/100006999/0b7058f8-c8cc-46ad-9000-3c6cd2c573e8">

## Note
It breaks under `768px` since I got lazy and didn't bother to handle sizes under that