### PR TITLE
200 refactor volunteer registrationcheck in flow

### DIFF
--- a/src/components/CancelFlowController.jsx
+++ b/src/components/CancelFlowController.jsx
@@ -1,0 +1,41 @@
+import {
+  Button,
+  Text,
+  Stack,
+  Modal,
+  ModalContent,
+  ModalBody,
+  ModalOverlay,
+  ModalCloseButton,
+} from '@chakra-ui/react';
+import Backend from '../utils/utils';
+
+
+const CancelFlowController = ({id, isOpen, onClose}) => {
+  const unregisterFromEvent = async (id) => {
+    console.log(id)
+    // Register for event
+    try {
+      const route = '/data/' + id
+      await Backend.delete(route);
+    } catch (e) {
+      console.log('Error deleting event data entry', e);
+    }
+  };
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+    <ModalOverlay />
+    <ModalContent>
+      <ModalCloseButton />
+      <ModalBody>
+        <Stack align="center" padding="1rem" gap="2rem">
+          <Text fontSize="2xl" align="center">Are you sure you want to cancel your registration?</Text>
+          <Button onClick={() => unregisterFromEvent(id)}>Confirm Cancellation</Button>
+        </Stack>
+      </ModalBody>
+    </ModalContent>
+    </Modal>
+  );
+}
+
+export default CancelFlowController;

--- a/src/components/CancelFlowController.jsx
+++ b/src/components/CancelFlowController.jsx
@@ -18,6 +18,7 @@ const CancelFlowController = ({id, isOpen, onClose}) => {
     try {
       const route = '/data/' + id
       await Backend.delete(route);
+      onClose();
     } catch (e) {
       console.log('Error deleting event data entry', e);
     }

--- a/src/components/EventRegistration/CancelFlowController.jsx
+++ b/src/components/EventRegistration/CancelFlowController.jsx
@@ -8,8 +8,8 @@ import {
   ModalOverlay,
   ModalCloseButton,
 } from '@chakra-ui/react';
-import Backend from '../utils/utils';
-
+import Backend from '../../utils/utils';
+import PropTypes from 'prop-types';
 
 const CancelFlowController = ({id, isOpen, onClose}) => {
   const unregisterFromEvent = async (id) => {
@@ -22,6 +22,8 @@ const CancelFlowController = ({id, isOpen, onClose}) => {
     } catch (e) {
       console.log('Error deleting event data entry', e);
     }
+    // Added this to update the page / no longer show unregistered events
+    window.location.reload(false);
   };
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -38,5 +40,11 @@ const CancelFlowController = ({id, isOpen, onClose}) => {
     </Modal>
   );
 }
+
+CancelFlowController.propTypes = {
+  isOpen: PropTypes.bool,
+  onClose: PropTypes.func,
+  id: PropTypes.number,
+};
 
 export default CancelFlowController;

--- a/src/components/Events/EventFilteredGrid.jsx
+++ b/src/components/Events/EventFilteredGrid.jsx
@@ -20,7 +20,7 @@ import Fuse from 'fuse.js';
 
 import UserContext from '../../utils/UserContext';
 
-const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButton, isOpen, onlyRegistered=false }) => {
+const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButton, isOpen, onlyUnregistered=false }) => {
   const [events, setEvents] = useState([]);
   const [displayEvents, setDisplayEvents] = useState([]);
 
@@ -37,15 +37,14 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
   const getEvents = async () => {
     try {
       let eventsData;
-      if (onlyRegistered) {
+      if (onlyUnregistered) {
         // Will show only registered events
-        eventsData = await Backend.get('/events/currentEvents');
+        eventsData = await Backend.get(`data/unregistered/${user.id}`);
       } else {
         // Will show all events, default / previous behavior
-        eventsData = await Backend.get(`data/unregistered/${user.id}`);
+        eventsData = await Backend.get('/events/currentEvents');
       }
       setEvents(eventsData.data);
-      // setDates();
       setLocations(getLocation(eventsData.data));
       setDates(getDate(eventsData.data));
       const options = { keys: ['name', 'date', 'location'], includeScore: true }; //use date and locaiton selected
@@ -130,7 +129,6 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
       // result = fuseResult.filter(item => item.score <= 0.5).map(item => item.item);
       result = fuseResult.map(item => item.item);
     } else result = events;
-    // result.map((e) -> e.)
     setDisplayEvents(result);
   }, [name, location, date, fuse]);
 
@@ -208,7 +206,6 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
                     </Select>
                     <Select
                       bg={'white'}
-                      //   icon={<Icon as={CalendarIcon}/>}
                       onChange={handleDateChange}
                       placeholder="Select Date"
                       border={'2px solid var(--Secondary-Button-Color, #EFEFEF)'}
@@ -248,7 +245,6 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
                   <EventCard
                     {...element}
                     isSelected={selectedEvents.includes(element.id)}
-                    // showSelect={showSelect}
                     handleCheckboxChange={handleCheckboxChange}
                     getEvents={getEvents}
                     hasBorder={true}
@@ -268,7 +264,7 @@ EventFilteredGrid.propTypes = {
   setIsOpen: PropTypes.func.isRequired,
   setShowOpenDrawerButton: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
-  onlyRegistered: PropTypes.bool
+  onlyUnregistered: PropTypes.bool
 };
 
 export default EventFilteredGrid;

--- a/src/components/Events/EventFilteredGrid.jsx
+++ b/src/components/Events/EventFilteredGrid.jsx
@@ -10,7 +10,7 @@ import {
   Heading,
   HStack,
 } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { SearchIcon } from '@chakra-ui/icons';
 import PropTypes from 'prop-types';
 
@@ -18,7 +18,9 @@ import EventCard from '../../components/Events/EventCard';
 import Backend from '../../utils/utils';
 import Fuse from 'fuse.js';
 
-const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButton, isOpen }) => {
+import UserContext from '../../utils/UserContext';
+
+const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButton, isOpen, onlyRegistered=false }) => {
   const [events, setEvents] = useState([]);
   const [displayEvents, setDisplayEvents] = useState([]);
 
@@ -30,9 +32,18 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
   const [date, setDate] = useState('');
   const [fuse, setFuse] = useState();
 
+  const { user } = useContext(UserContext);
+
   const getEvents = async () => {
     try {
-      const eventsData = await Backend.get('/events/currentEvents');
+      let eventsData;
+      if (onlyRegistered) {
+        // Will show only registered events
+        eventsData = await Backend.get(`data/unregistered/${user.id}`);
+      } else {
+        // Will show all events, default / previous behavior
+        eventsData = await Backend.get('/events/currentEvents');
+      }
       setEvents(eventsData.data);
       // setDates();
       setLocations(getLocation(eventsData.data));
@@ -257,6 +268,7 @@ EventFilteredGrid.propTypes = {
   setIsOpen: PropTypes.func.isRequired,
   setShowOpenDrawerButton: PropTypes.func.isRequired,
   isOpen: PropTypes.bool.isRequired,
+  onlyRegistered: PropTypes.bool
 };
 
 export default EventFilteredGrid;

--- a/src/components/Events/EventFilteredGrid.jsx
+++ b/src/components/Events/EventFilteredGrid.jsx
@@ -39,10 +39,10 @@ const EventFilteredGrid = ({ setCurrentEventId, setIsOpen, setShowOpenDrawerButt
       let eventsData;
       if (onlyRegistered) {
         // Will show only registered events
-        eventsData = await Backend.get(`data/unregistered/${user.id}`);
+        eventsData = await Backend.get('/events/currentEvents');
       } else {
         // Will show all events, default / previous behavior
-        eventsData = await Backend.get('/events/currentEvents');
+        eventsData = await Backend.get(`data/unregistered/${user.id}`);
       }
       setEvents(eventsData.data);
       // setDates();

--- a/src/components/Events/FeaturedDashboard.jsx
+++ b/src/components/Events/FeaturedDashboard.jsx
@@ -1,9 +1,11 @@
 import { Heading, Flex, Grid, GridItem, IconButton, useBreakpointValue } from '@chakra-ui/react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import Backend from '../../utils/utils';
 import EventCard from './EventCard';
 import { RxCaretLeft } from 'react-icons/rx';
 import PropTypes from 'prop-types';
+
+import UserContext from '../../utils/UserContext';
 
 const FeaturedDashboard = ({
   setCurrentEventId,
@@ -15,9 +17,12 @@ const FeaturedDashboard = ({
   const [featuredEvents, setFeaturedEvents] = useState([]);
   const numEvents = useBreakpointValue({ base: 1, md: 2, xl: 2 });
 
+  const { user } = useContext(UserContext);
+
   const getEvents = async () => {
     try {
-      const eventsData = await Backend.get('/events');
+      // const eventsData = await Backend.get('/events');
+      const eventsData = await Backend.get(`/data/unregistered/${user.id}`);
       setFeaturedEvents(eventsData.data.slice(0, numEvents));
     } catch (err) {
       console.log(`Error getting events: `, err.message);

--- a/src/components/Events/FeaturedDashboard.jsx
+++ b/src/components/Events/FeaturedDashboard.jsx
@@ -21,7 +21,6 @@ const FeaturedDashboard = ({
 
   const getEvents = async () => {
     try {
-      // const eventsData = await Backend.get('/events');
       const eventsData = await Backend.get(`/data/unregistered/${user.id}`);
       setFeaturedEvents(eventsData.data.slice(0, numEvents));
     } catch (err) {

--- a/src/components/VolunteerSideView.jsx
+++ b/src/components/VolunteerSideView.jsx
@@ -43,24 +43,28 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
   }, [eventData]);
   const [eventDataVolunteer, setEventDataVolunteer] = useState([]);
   const { user } = useContext(UserContext);
-  console.log('users', user);
-  console.log('eventid', eventDataVolunteer[0]);
+  // console.log('users', user);
+  // console.log('eventid', eventDataVolunteer[0]);
 
   // const [dateObj, setDateObj] = useState(new Date());
   // const dateObj = new Date(Date.parse(eventData.date));
   // console.log(eventData);
 
-  const {
-    isOpen: isRegistrationFlowOpen,
-    onOpen: onRegistrationFlowOpen,
-    onClose: onRegistrationFlowClose,
-  } = useDisclosure();
+  // const {
+  //   isOpen: isRegistrationFlowOpen,
+  //   onOpen: onRegistrationFlowOpen,
+  //   onClose: onRegistrationFlowClose,
+  // } = useDisclosure();
 
   const {
     isOpen: isCancelFlowOpen,
     onOpen: onCancelFlowOpen,
     onClose: onCancelFlowClose,
   } = useDisclosure();
+
+  useEffect(() => {
+    console.log('?', eventDataVolunteer);
+  }, [eventDataVolunteer]);
 
   // At the top of your component
 
@@ -82,7 +86,7 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
   }, [eventId, user.id]);
 
   // console.log('this is the event id:', eventId);
-  console.log('this is the', eventData);
+  // console.log('this is the', eventData);
   // console.log('d', dateObj)
   //* download ics file by calling backend
   // Assuming `eventData` is part of the state as shown previously
@@ -211,6 +215,7 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
         </Flex>
       </HStack>
 
+      {(eventDataVolunteer.length >= 1) &&
       <Box
         p={'0.8em'}
         borderWidth={'0.2em'}
@@ -261,6 +266,7 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
           <Text fontWeight={'bold'}>{eventDataVolunteer[0]?.number_in_party}</Text>
         </Flex>
       </Box>
+      }
 
       <VStack mb={'0.5em'} gap={'0.6em'}>
         <Flex justifyContent={'center'} alignItems={'center'} borderRadius={'md'} w={'100%'}>

--- a/src/components/VolunteerSideView.jsx
+++ b/src/components/VolunteerSideView.jsx
@@ -20,8 +20,8 @@ import { IoPeopleSharp } from 'react-icons/io5';
 import { IoMdLink } from 'react-icons/io';
 import { RxCaretRight } from 'react-icons/rx';
 import HappeningInChip from '../components/HappeningInChip/HappeningInChip';
-// import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
-import CancelFlowController from '../components/CancelFlowController';
+import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
+import CancelFlowController from './EventRegistration/CancelFlowController.jsx';
 import ical, { ICalCalendarMethod } from 'ical-generator';
 import UserContext from '../utils/UserContext.jsx';
 import { getEventDataVolunteerId } from '../utils/eventsUtils';
@@ -50,11 +50,11 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
   // const dateObj = new Date(Date.parse(eventData.date));
   // console.log(eventData);
 
-  // const {
-  //   isOpen: isRegistrationFlowOpen,
-  //   onOpen: onRegistrationFlowOpen,
-  //   onClose: onRegistrationFlowClose,
-  // } = useDisclosure();
+  const {
+    isOpen: isRegistrationFlowOpen,
+    onOpen: onRegistrationFlowOpen,
+    onClose: onRegistrationFlowClose,
+  } = useDisclosure();
 
   const {
     isOpen: isCancelFlowOpen,
@@ -371,20 +371,24 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
         </Flex>
       </Flex>
 
-      {/* <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
-        Register
-      </Button> */}
-      <Button colorScheme="gray" color={"#919191"} onClick={onCancelFlowOpen}>
-        <DeleteIcon mr="3%"/>
-        <Text>Cancel Registration</Text>
-      </Button>
-      {/* {isRegistrationFlowOpen && (
+      {(eventDataVolunteer.length >= 1) ? (
+        <Button colorScheme="gray" color={"#919191"} onClick={onCancelFlowOpen}>
+          <DeleteIcon mr="3%"/>
+          <Text>Cancel Registration</Text>
+        </Button>
+      ) : (
+        <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
+          Register
+        </Button>
+      )}
+
+      {isRegistrationFlowOpen && (
         <RegistrationFlowController
           isOpen={isRegistrationFlowOpen}
           onClose={onRegistrationFlowClose}
           eventId={eventId}
         />
-      )} */}
+      )}
       {
         isCancelFlowOpen && (
           <CancelFlowController id={eventDataVolunteer[0]['id']} isOpen={isCancelFlowOpen} onClose={onCancelFlowClose}/>

--- a/src/components/VolunteerSideView.jsx
+++ b/src/components/VolunteerSideView.jsx
@@ -29,7 +29,6 @@ import { getEventDataVolunteerId } from '../utils/eventsUtils';
 const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
   const [eventData, setEventData] = useState();
   const [isReadMore, setIsReadMore] = useState(false);
-  // const [calendarSelected, setCalendarSelected] = useState(false);
   const [mapSelected, setMapSelected] = useState(false);
   const [dateObj, setDateObj] = useState(new Date());
 
@@ -43,12 +42,6 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
   }, [eventData]);
   const [eventDataVolunteer, setEventDataVolunteer] = useState([]);
   const { user } = useContext(UserContext);
-  // console.log('users', user);
-  // console.log('eventid', eventDataVolunteer[0]);
-
-  // const [dateObj, setDateObj] = useState(new Date());
-  // const dateObj = new Date(Date.parse(eventData.date));
-  // console.log(eventData);
 
   const {
     isOpen: isRegistrationFlowOpen,

--- a/src/components/VolunteerSideView.jsx
+++ b/src/components/VolunteerSideView.jsx
@@ -13,14 +13,15 @@ import PropTypes from 'prop-types';
 import { useState, useEffect, useContext } from 'react';
 import { Icon } from '@chakra-ui/react';
 import { getEventById } from '../utils/eventsUtils';
-import { EditIcon, CalendarIcon } from '@chakra-ui/icons';
+import { EditIcon, CalendarIcon, DeleteIcon } from '@chakra-ui/icons';
 import logos_google_calendar from '../assets/logos_google-calendar.svg';
 import logos_google_maps from '../assets/logos_google-maps.svg';
 import { IoPeopleSharp } from 'react-icons/io5';
 import { IoMdLink } from 'react-icons/io';
 import { RxCaretRight } from 'react-icons/rx';
 import HappeningInChip from '../components/HappeningInChip/HappeningInChip';
-import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
+// import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
+import CancelFlowController from '../components/CancelFlowController';
 import ical, { ICalCalendarMethod } from 'ical-generator';
 import UserContext from '../utils/UserContext.jsx';
 import { getEventDataVolunteerId } from '../utils/eventsUtils';
@@ -31,6 +32,8 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
   // const [calendarSelected, setCalendarSelected] = useState(false);
   const [mapSelected, setMapSelected] = useState(false);
   const [dateObj, setDateObj] = useState(new Date());
+
+
 
   // only parse the date if eventData has been retrieved
   useEffect(() => {
@@ -51,6 +54,12 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
     isOpen: isRegistrationFlowOpen,
     onOpen: onRegistrationFlowOpen,
     onClose: onRegistrationFlowClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isCancelFlowOpen,
+    onOpen: onCancelFlowOpen,
+    onClose: onCancelFlowClose,
   } = useDisclosure();
 
   // At the top of your component
@@ -356,16 +365,25 @@ const VolunteerSideView = ({ eventId, onClose, setShowOpenDrawerButton }) => {
         </Flex>
       </Flex>
 
-      <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
+      {/* <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
         Register
+      </Button> */}
+      <Button colorScheme="gray" color={"#919191"} onClick={onCancelFlowOpen}>
+        <DeleteIcon mr="3%"/>
+        <Text>Cancel Registration</Text>
       </Button>
-      {isRegistrationFlowOpen && (
+      {/* {isRegistrationFlowOpen && (
         <RegistrationFlowController
           isOpen={isRegistrationFlowOpen}
           onClose={onRegistrationFlowClose}
           eventId={eventId}
         />
-      )}
+      )} */}
+      {
+        isCancelFlowOpen && (
+          <CancelFlowController id={eventDataVolunteer[0]['id']} isOpen={isCancelFlowOpen} onClose={onCancelFlowClose}/>
+        )
+      }
     </Flex>
   ) : (
     <Text>Loading Event...</Text>

--- a/src/components/VolunteerSideViewDrawer.jsx
+++ b/src/components/VolunteerSideViewDrawer.jsx
@@ -20,8 +20,8 @@ import { RxCaretRight } from 'react-icons/rx';
 import HappeningInChip from './HappeningInChip/HappeningInChip';
 import { getEventDataVolunteerId } from '../utils/eventsUtils';
 import UserContext from '../utils/UserContext.jsx';
-// import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
-import CancelFlowController from '../components/CancelFlowController';
+import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
+import CancelFlowController from './EventRegistration/CancelFlowController.jsx';
 
 const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerButton }) => {
   const [eventData, setEventData] = useState([]);
@@ -35,13 +35,12 @@ const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerBu
 
   // const [dateObj, setDateObj] = useState(new Date());
   const dateObj = new Date(Date.parse(eventData.date));
-  // console.log(eventData);
 
-  // const {
-  //   isOpen: isRegistrationFlowOpen,
-  //   onOpen: onRegistrationFlowOpen,
-  //   onClose: onRegistrationFlowClose,
-  // } = useDisclosure();
+  const {
+    isOpen: isRegistrationFlowOpen,
+    onOpen: onRegistrationFlowOpen,
+    onClose: onRegistrationFlowClose,
+  } = useDisclosure();
 
   const {
     isOpen: isCancelFlowOpen,
@@ -134,56 +133,58 @@ const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerBu
               </Flex>
             </HStack>
 
-            <Box
-              p={'0.8em'}
-              borderWidth={'0.2em'}
-              borderRadius="lg"
-              marginY={'0.8em'}
-              borderColor={'#EFEFEF'}
-            >
-              <Flex justify={'space-between'} alignItems={'center'}>
-                <Text fontWeight={'bold'}>Your event status</Text>
-                <Box px={'0.4em'} borderRadius={'md'} bg="gray.200" mb={'0.3em'}>
-                  <EditIcon />
-                </Box>
-              </Flex>
-              <Flex justify={'space-between'} alignItems={'center'}>
-                <Text>Type</Text>
-                <Flex
-                  flexDir={'row'}
-                  px={'0.4em'}
-                  borderRadius={'md'}
-                  bg="gray.200"
-                  mb={'0.3em'}
-                  justifyContent={'center'}
-                  alignItems={'center'}
-                  gap={'0.3em'}
-                >
-                  <IoPeopleSharp color="purple" />
-                  <Text>{eventDataVolunteer[0]?.number_in_party > 1 ? 'Group' : 'Individual'}</Text>
+            {(eventDataVolunteer.length >= 1) && (
+              <Box
+                p={'0.8em'}
+                borderWidth={'0.2em'}
+                borderRadius="lg"
+                marginY={'0.8em'}
+                borderColor={'#EFEFEF'}
+              >
+                <Flex justify={'space-between'} alignItems={'center'}>
+                  <Text fontWeight={'bold'}>Your event status</Text>
+                  <Box px={'0.4em'} borderRadius={'md'} bg="gray.200" mb={'0.3em'}>
+                    <EditIcon />
+                  </Box>
                 </Flex>
-              </Flex>
-              <Flex justify={'space-between'} alignItems={'center'}>
-                <Text>Registration</Text>
-                <Flex
-                  flexDir={'row'}
-                  px={'0.4em'}
-                  borderRadius={'md'}
-                  borderWidth={'0.15em'}
-                  mb={'0.3em'}
-                  justifyContent={'center'}
-                  alignItems={'center'}
-                  gap={'0.3em'}
-                >
-                  <CalendarIcon color="purple" />
-                  <Text>{eventDataVolunteer[0]?.is_checked_in ? 'Checked-in' : 'Registered'}</Text>
+                <Flex justify={'space-between'} alignItems={'center'}>
+                  <Text>Type</Text>
+                  <Flex
+                    flexDir={'row'}
+                    px={'0.4em'}
+                    borderRadius={'md'}
+                    bg="gray.200"
+                    mb={'0.3em'}
+                    justifyContent={'center'}
+                    alignItems={'center'}
+                    gap={'0.3em'}
+                  >
+                    <IoPeopleSharp color="purple" />
+                    <Text>{eventDataVolunteer[0]?.number_in_party > 1 ? 'Group' : 'Individual'}</Text>
+                  </Flex>
                 </Flex>
-              </Flex>
-              <Flex justify={'space-between'} alignItems={'center'}>
-                <Text>Party size</Text>
-                <Text fontWeight={'bold'}>{eventDataVolunteer[0]?.number_in_party}</Text>
-              </Flex>
-            </Box>
+                <Flex justify={'space-between'} alignItems={'center'}>
+                  <Text>Registration</Text>
+                  <Flex
+                    flexDir={'row'}
+                    px={'0.4em'}
+                    borderRadius={'md'}
+                    borderWidth={'0.15em'}
+                    mb={'0.3em'}
+                    justifyContent={'center'}
+                    alignItems={'center'}
+                    gap={'0.3em'}
+                  >
+                    <CalendarIcon color="purple" />
+                    <Text>{eventDataVolunteer[0]?.is_checked_in ? 'Checked-in' : 'Registered'}</Text>
+                  </Flex>
+                </Flex>
+                <Flex justify={'space-between'} alignItems={'center'}>
+                  <Text>Party size</Text>
+                  <Text fontWeight={'bold'}>{eventDataVolunteer[0]?.number_in_party}</Text>
+                </Flex>
+              </Box>
+            )}
 
             <VStack mb={'0.5em'} gap={'0.6em'}>
               <Flex justifyContent={'center'} alignItems={'center'} borderRadius={'md'} w={'100%'}>
@@ -278,20 +279,24 @@ const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerBu
               </HStack>
             </Flex>
 
-            {/* <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
-              Register
-            </Button> */}
-            <Button colorScheme="gray" color={"#919191"} onClick={onCancelFlowOpen}>
-              <DeleteIcon mr="3%"/>
-              <Text>Cancel Registration</Text>
-            </Button>
-            {/* {isRegistrationFlowOpen && (
+            {(eventDataVolunteer.length >= 1) ? (
+              <Button colorScheme="gray" color={"#919191"} onClick={onCancelFlowOpen}>
+                <DeleteIcon mr="3%"/>
+                <Text>Cancel Registration</Text>
+              </Button>
+            ) : (
+              <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
+                Register
+              </Button>
+            )}
+
+            {isRegistrationFlowOpen && (
               <RegistrationFlowController
                 isOpen={isRegistrationFlowOpen}
                 onClose={onRegistrationFlowClose}
                 eventId={eventId}
               />
-            )} */}
+            )}
             {
               isCancelFlowOpen && (
               <CancelFlowController id={eventDataVolunteer[0]['id']} isOpen={isCancelFlowOpen} onClose={onCancelFlowClose}/>

--- a/src/components/VolunteerSideViewDrawer.jsx
+++ b/src/components/VolunteerSideViewDrawer.jsx
@@ -271,8 +271,11 @@ const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerBu
               </HStack>
             </Flex>
 
-            <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
+            {/* <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
               Register
+            </Button> */}
+            <Button backgroundColor={'#0075FF'} color={'white'} >
+              Cancel
             </Button>
             {isRegistrationFlowOpen && (
               <RegistrationFlowController

--- a/src/components/VolunteerSideViewDrawer.jsx
+++ b/src/components/VolunteerSideViewDrawer.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import { useState, useEffect, useContext } from 'react';
 import { Icon } from '@chakra-ui/react';
 import { getEventById } from '../utils/eventsUtils';
-import { EditIcon, CalendarIcon } from '@chakra-ui/icons';
+import { EditIcon, CalendarIcon, DeleteIcon } from '@chakra-ui/icons';
 import logos_google_calendar from '../assets/logos_google-calendar.svg';
 import logos_google_maps from '../assets/logos_google-maps.svg';
 import { IoPeopleSharp } from 'react-icons/io5';
@@ -20,7 +20,8 @@ import { RxCaretRight } from 'react-icons/rx';
 import HappeningInChip from './HappeningInChip/HappeningInChip';
 import { getEventDataVolunteerId } from '../utils/eventsUtils';
 import UserContext from '../utils/UserContext.jsx';
-import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
+// import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
+import CancelFlowController from '../components/CancelFlowController';
 
 const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerButton }) => {
   const [eventData, setEventData] = useState([]);
@@ -36,10 +37,16 @@ const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerBu
   const dateObj = new Date(Date.parse(eventData.date));
   // console.log(eventData);
 
+  // const {
+  //   isOpen: isRegistrationFlowOpen,
+  //   onOpen: onRegistrationFlowOpen,
+  //   onClose: onRegistrationFlowClose,
+  // } = useDisclosure();
+
   const {
-    isOpen: isRegistrationFlowOpen,
-    onOpen: onRegistrationFlowOpen,
-    onClose: onRegistrationFlowClose,
+    isOpen: isCancelFlowOpen,
+    onOpen: onCancelFlowOpen,
+    onClose: onCancelFlowClose,
   } = useDisclosure();
 
   useEffect(() => {
@@ -274,16 +281,22 @@ const VolunteerSideViewDrawer = ({ eventId, isOpen, onClose, setShowOpenDrawerBu
             {/* <Button backgroundColor={'#0075FF'} color={'white'} onClick={onRegistrationFlowOpen}>
               Register
             </Button> */}
-            <Button backgroundColor={'#0075FF'} color={'white'} >
-              Cancel
+            <Button colorScheme="gray" color={"#919191"} onClick={onCancelFlowOpen}>
+              <DeleteIcon mr="3%"/>
+              <Text>Cancel Registration</Text>
             </Button>
-            {isRegistrationFlowOpen && (
+            {/* {isRegistrationFlowOpen && (
               <RegistrationFlowController
                 isOpen={isRegistrationFlowOpen}
                 onClose={onRegistrationFlowClose}
                 eventId={eventId}
               />
-            )}
+            )} */}
+            {
+              isCancelFlowOpen && (
+              <CancelFlowController id={eventDataVolunteer[0]['id']} isOpen={isCancelFlowOpen} onClose={onCancelFlowClose}/>
+            )
+      }
           </Flex>
         </DrawerBody>
       </DrawerContent>

--- a/src/pages/VolunteerEventPage.jsx
+++ b/src/pages/VolunteerEventPage.jsx
@@ -7,7 +7,6 @@ import NavbarContext from '../utils/NavbarContext';
 import VolunteerSideView from '../components/VolunteerSideView.jsx';
 import { useBreakpoint, useDisclosure } from '@chakra-ui/react';
 import VolunteerSideViewDrawer from '../components/VolunteerSideViewDrawer.jsx';
-// import RegistrationFlowController from '../components/EventRegistration/RegistrationFlowController.jsx';
 
 const VolunteerEventPage = () => {
   const { isOpen: isDrawerOpen, onOpen: onDrawerOpen, onClose: onDrawerClose } = useDisclosure();
@@ -25,27 +24,11 @@ const VolunteerEventPage = () => {
     onDrawerOpen();
   };
 
-  // const handleClose = () => {
-  //   onDrawerClose();
-  // };
+
   console.log('test' + currentEventId);
-  // const {
-  //   isOpen: isRegistrationFlowOpen,
-  //   onOpen: onRegistrationFlowOpen,
-  //   onClose: onRegistrationFlowClose,
-  // } = useDisclosure({ defaultIsOpen: false });
 
   return (
     <Flex dir="column">
-      {/* controller */}
-      {/* <Button onClick={onRegistrationFlowOpen}>Open!</Button>
-      {isRegistrationFlowOpen && (
-        <RegistrationFlowController
-          isOpen={isRegistrationFlowOpen}
-          onClose={onRegistrationFlowClose}
-          eventId={currentEventId}
-        />
-      )} */}
       {/* <RegistrationModal /> */}
       <Box bg="#E6EAEF" flexGrow={1} minW="1px" minH={'100vh'}>
         <Flex

--- a/src/pages/VolunteerEventPage.jsx
+++ b/src/pages/VolunteerEventPage.jsx
@@ -103,6 +103,7 @@ const VolunteerEventPage = () => {
           setIsOpen={setIsOpen}
           setShowOpenDrawerButton={setShowOpenDrawerButton}
           isOpen={isOpen}
+          onlyUnregistered={true}
         />
       </Box>
       {/* Drawer Component */}

--- a/src/pages/VolunteerHomePage.jsx
+++ b/src/pages/VolunteerHomePage.jsx
@@ -44,10 +44,7 @@ const VolunteerHomePage = () => {
 
   const getEvents = async () => {
     try {
-      console.log
-      console.log(user)
       const eventsData = await Backend.get(`data/registered/${user.id}`);
-      console.log(eventsData);
       setEvents(eventsData.data);
       const options = { keys: ['name', 'date', 'location'], includeScore: true };
       setFuse(new Fuse(eventsData.data, options));
@@ -92,6 +89,7 @@ const VolunteerHomePage = () => {
       result = fuseResult.map(item => item.item);
     } else result = events;
     setDisplayEvents(result);
+    console.log(result);
   }, [name, events, location, date, fuse]);
 
   const [currentEventId, setCurrentEventId] = useState(-1);


### PR DESCRIPTION
## Changes
- Matched design flow
- Event side bar now conditionally shows check in or cancel registration
    - For both mobile and desktop
- Only upcoming, non-registered events will show up on the events page
- Only past/upcoming registered events show up on the volunteer home page
- The events stats thing is also conditionally rendered
- Updated featured events to show two most recent upcoming non-registered events

## Testing
- Made new user account
- Registered from events, unregistered
- Confirmed events only showed up on the right page and that the side bar was rendered correctly
- Confirmed event was deleted from event_data when user unregistered

## Backend
- Created new backend route
- /data/unregistered/:volunteerid:
- See backend branch by same name